### PR TITLE
feat: Add cross-platform Ansible `ping` task with OS auto-detection

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,15 +1,22 @@
 ---
 name: Pre-Commit
 on:
-  push:
+  merge_group:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize
-  # Run once a week (see https://crontab.guru)
+      - reopened
+  push:
+    branches:
+      - main
   schedule:
+    # Run once a week (see https://crontab.guru)
     - cron: "0 0 * * 0"
   workflow_dispatch:
+
 jobs:
   pre-commit:
     name: Update pre-commit hooks and run pre-commit

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,8 +1,7 @@
 # 🎭 Ansible Taskfile Tasks
 
 This directory contains reusable Taskfile tasks for Ansible development
-operations, including molecule testing, linting, host reachability validation,
-and changelog management.
+operations, including molecule testing, linting, and changelog management.
 
 ## 📋 Prerequisites
 
@@ -14,13 +13,13 @@ and changelog management.
 - [jq](https://stedolan.github.io/jq/download/) installed (for JSON processing)
 - [antsibull-changelog](https://github.com/ansible-community/antsibull-changelog)
   installed
-- Docker installed (required for Molecule and `act`)
+- Docker installed (required for Molecule and act)
 
 ## 🎯 Available Tasks
 
 ### changelog-lint
 
-Lints the changelog using `antsibull-changelog` to ensure it follows the proper format.
+Lints the changelog using antsibull-changelog to ensure it follows the proper format.
 
 ```bash
 task changelog-lint
@@ -57,6 +56,14 @@ Example output:
 task: [ansible:gen-changelog] Generating changelog for release 2.0.0
 task: [ansible:changelog-lint] antsibull-changelog lint
 task: [ansible:changelog-release] antsibull-changelog release --version $NEXT_VERSION
+```
+
+### lint-ansible
+
+Runs Ansible Lint with custom configuration from `.hooks/linters/ansible-lint.yaml`.
+
+```bash
+task lint-ansible
 ```
 
 ### ping
@@ -126,32 +133,33 @@ Auto-detecting host types and pinging each…
 PLAY [all] *********************************************************************
 
 TASK [Gathering Facts] ********************************************************
-ok: [ashley-kali]
-ok: [vincent-kali]
-ok: [srv03]
+ok: [host1-ubuntu]
+ok: [host2-ubuntu]
+ok: [windows-host]
 ok: [localhost]
 
 TASK [Ping Windows hosts] *****************************************************
-ok: [srv03]
-ok: [dc01]
-skipping: [vincent-kali]
+ok: [windows-host]
+skipping: [host1-ubuntu]
+skipping: [host2-ubuntu]
 skipping: [localhost]
 
 TASK [Ping macOS hosts] *******************************************************
 ok: [localhost]
-skipping: [srv03]
-skipping: [dc01]
+skipping: [host1-ubuntu]
+skipping: [host2-ubuntu]
+skipping: [windows-host]
 
 TASK [Ping Linux hosts] *******************************************************
-ok: [vincent-kali]
-ok: [ashley-kali]
+ok: [host1-ubuntu]
+ok: [host2-ubuntu]
+skipping: [windows-host]
 skipping: [localhost]
-skipping: [srv03]
 
 PLAY RECAP ********************************************************************
-ashley-kali      : ok=2  changed=0  failed=0  skipped=2
-vincent-kali     : ok=2  changed=0  failed=0  skipped=2
-srv03            : ok=2  changed=0  failed=0  skipped=2
+host1-ubuntu     : ok=2  changed=0  failed=0  skipped=2
+host2-ubuntu     : ok=2  changed=0  failed=0  skipped=2
+windows-host     : ok=2  changed=0  failed=0  skipped=2
 localhost        : ok=2  changed=0  failed=0  skipped=2
 ```
 
@@ -162,12 +170,16 @@ localhost        : ok=2  changed=0  failed=0  skipped=2
   local macOS)
 - Cleans up temporary playbooks after execution
 
-Let me know if you want a table view of variables or more output formatting examples.
-
 ### run-molecule-action
 
-Runs GitHub Actions Molecule workflow locally using `act`. Useful for testing
-roles and playbooks prior to pushing.
+Runs GitHub Actions molecule workflow locally using act. Supports testing
+specific components. This task expects a GitHub Actions workflow file at
+`.github/workflows/molecule.yaml`. See example workflow implementations:
+
+- [workstation-collection/molecule.yaml](https://github.com/CowDogMoo/ansible-collection-workstation/blob/main/.github/workflows/molecule.yaml)
+  - Example workflow for testing workstation configuration roles
+- [arsenal-collection/molecule.yaml](https://github.com/l50/ansible-collection-arsenal/blob/main/.github/workflows/molecule.yaml)
+  - Example workflow for testing security tooling roles
 
 **Optional Variables:**
 
@@ -178,21 +190,16 @@ roles and playbooks prior to pushing.
 # Run all tests
 task run-molecule-action
 
-# Test a specific role
-task run-molecule-action ROLE=zsh_setup
+# Test specific role
+task run-molecule-action ROLE=asdf
 
-# Test a specific playbook
+# Test specific playbook
 task run-molecule-action PLAYBOOK=workstation
 ```
 
-See example workflows:
-
-- [workstation-collection/molecule.yaml](https://github.com/CowDogMoo/ansible-collection-workstation/blob/main/.github/workflows/molecule.yaml)
-- [arsenal-collection/molecule.yaml](https://github.com/l50/ansible-collection-arsenal/blob/main/.github/workflows/molecule.yaml)
-
 ### run-molecule-tests
 
-Runs Molecule tests for all roles in the collection sequentially and logs the output.
+Executes Molecule tests for all roles in the collection sequentially.
 
 ```bash
 task run-molecule-tests
@@ -201,11 +208,10 @@ task run-molecule-tests
 ## 🔍 Important Notes
 
 - All tasks include proper error handling and logging to `logs/molecule_tests.log`
-- Molecule tests rely on the local `ansible.cfg` configuration
-- `ping` task includes robust OS detection logic (Windows/macOS/Linux)
-- `run-molecule-action` supports macOS ARM64 compatibility automatically
-- Docker containers are cleaned up between test runs
-- Changelog generation requires explicit `NEXT_VERSION`
+- Molecule tests use the project-specific `ansible.cfg` configuration
+- The `run-molecule-action` task automatically handles ARM64 architecture on macOS
+- Docker containers are automatically cleaned up between test runs
+- All changelog operations require proper version specification
 
 ## 🔧 Importing Tasks
 

--- a/ansible/Taskfile.yaml
+++ b/ansible/Taskfile.yaml
@@ -33,28 +33,65 @@ tasks:
         ansible-lint --force-color -c .hooks/linters/ansible-lint.yaml
     silent: true
 
-  run-molecule-action:
-    desc: "Run GitHub Actions molecule workflow using act. Optionally specify ROLE or PLAYBOOK"
+  ping:
+    desc: "Ping: cross-OS, works on all/group/pattern/host specification, robust. Auto-detects Windows and Linux hosts."
     vars:
-      ROLE: '{{.ROLE | default ""}}'
-      PLAYBOOK: '{{.PLAYBOOK | default ""}}'
-      IS_MAC_ARM: '{{if and (eq OS "Darwin") (eq ARCH "arm64")}}true{{else}}false{{end}}'
-      ARCH_FLAG: '{{if eq .IS_MAC_ARM "true"}}--container-architecture linux/amd64{{end}}'
+      INVENTORY: '{{.INVENTORY}}'
+      HOSTS: '{{.HOSTS | default "all"}}'
+      DEBUG: '{{.DEBUG | default "false"}}'
+      OS_TYPE: '{{.OS_TYPE | default "auto"}}'
     cmds:
       - |
-        # Clean up any existing act containers
-        docker rm -f $(docker ps -q -f name=act-Molecule-Test) 2>/dev/null || true
-        if [ -n "{{.ROLE}}" ]; then
-          echo '{"inputs":{"ROLE":"{{.ROLE}}"}}' > /tmp/github-event.json
-          act -W .github/workflows/molecule.yaml {{.ARCH_FLAG}} -e /tmp/github-event.json
-          rm /tmp/github-event.json
-        elif [ -n "{{.PLAYBOOK}}" ]; then
-          echo '{"inputs":{"PLAYBOOK":"{{.PLAYBOOK}}"}}' > /tmp/github-event.json
-          act -W .github/workflows/molecule.yaml {{.ARCH_FLAG}} -e /tmp/github-event.json
-          rm /tmp/github-event.json
-        else
-          act -W .github/workflows/molecule.yaml {{.ARCH_FLAG}}
+        # For explicit OS type, just use the appropriate module
+        if [ "{{.OS_TYPE}}" = "windows" ]; then
+          echo "Using win_ping module for all hosts (OS_TYPE=windows)"
+          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m win_ping
+          exit $?
+        elif [ "{{.OS_TYPE}}" = "linux" ]; then
+          echo "Using ping module for all hosts (OS_TYPE=linux)"
+          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m ping
+          exit $?
         fi
+
+        # When OS_TYPE=auto (default), we need to handle mixed environments
+        echo "Auto-detecting host types for ping..."
+
+        # Check if we have Linux hosts
+        echo "Pinging Linux hosts..."
+        LINUX_RESULT=0
+        LINUX_HOSTS=$(ansible -i "{{.INVENTORY}}" -m ping {{.HOSTS}} 2>/dev/null | grep SUCCESS | awk '{print $1}' | tr -d ':' | tr '\n' ',')
+        if [ -n "$LINUX_HOSTS" ]; then
+          echo "Successfully pinged Linux hosts: $LINUX_HOSTS"
+        fi
+
+        # Check if we have Windows hosts
+        echo "Pinging Windows hosts..."
+        WIN_RESULT=0
+        WIN_HOSTS=$(ansible -i "{{.INVENTORY}}" -m win_ping {{.HOSTS}} 2>/dev/null | grep SUCCESS | awk '{print $1}' | tr -d ':' | tr '\n' ',')
+        if [ -n "$WIN_HOSTS" ]; then
+          echo "Successfully pinged Windows hosts: $WIN_HOSTS"
+        fi
+
+        # Print combined successful results
+        echo "===== PING RESULTS ====="
+        if [ -n "$LINUX_HOSTS" ]; then
+          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible -i "{{.INVENTORY}}" -m ping ${LINUX_HOSTS%,}
+        fi
+
+        if [ -n "$WIN_HOSTS" ]; then
+          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible -i "{{.INVENTORY}}" -m win_ping ${WIN_HOSTS%,}
+        fi
+
+        # Check if we covered all hosts
+        SUCCESSFUL_HOSTS="$LINUX_HOSTS$WIN_HOSTS"
+        if [ -z "$SUCCESSFUL_HOSTS" ]; then
+          echo "ERROR: No hosts could be pinged with either ping or win_ping!"
+          exit 1
+        fi
+
+        # Always exit successfully if at least one host was pinged
+        exit 0
+    silent: false
 
   run-molecule-tests:
     desc: "Run Molecule tests for all roles"

--- a/ansible/Taskfile.yaml
+++ b/ansible/Taskfile.yaml
@@ -37,60 +37,49 @@ tasks:
     desc: "Ping: cross-OS, works on all/group/pattern/host specification, robust. Auto-detects Windows and Linux hosts."
     vars:
       INVENTORY: '{{.INVENTORY}}'
-      HOSTS: '{{.HOSTS | default "all"}}'
-      DEBUG: '{{.DEBUG | default "false"}}'
-      OS_TYPE: '{{.OS_TYPE | default "auto"}}'
+      HOSTS:     '{{.HOSTS | default "all"}}'
+      DEBUG:     '{{.DEBUG | default "false"}}'
+      OS_TYPE:   '{{.OS_TYPE | default "auto"}}'
     cmds:
       - |
-        # For explicit OS type, just use the appropriate module
+        # Explicit OS_TYPE shortcuts
         if [ "{{.OS_TYPE}}" = "windows" ]; then
           echo "Using win_ping module for all hosts (OS_TYPE=windows)"
-          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m win_ping
+          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}\
+            ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m win_ping
           exit $?
         elif [ "{{.OS_TYPE}}" = "linux" ]; then
           echo "Using ping module for all hosts (OS_TYPE=linux)"
-          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m ping
+          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}\
+            ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m ping
           exit $?
         fi
 
-        # When OS_TYPE=auto (default), we need to handle mixed environments
-        echo "Auto-detecting host types for ping..."
+        # Auto-detect & ping once per host via an inline playbook
+        echo "Auto-detecting host types and pinging each host…"
 
-        # Check if we have Linux hosts
-        echo "Pinging Linux hosts..."
-        LINUX_RESULT=0
-        LINUX_HOSTS=$(ansible -i "{{.INVENTORY}}" -m ping {{.HOSTS}} 2>/dev/null | grep SUCCESS | awk '{print $1}' | tr -d ':' | tr '\n' ',')
-        if [ -n "$LINUX_HOSTS" ]; then
-          echo "Successfully pinged Linux hosts: $LINUX_HOSTS"
-        fi
+        PLAYBOOK_FILE=$(mktemp /tmp/ping_playbook.XXXXXX.yml)
+        cat > "$PLAYBOOK_FILE" <<'EOF'
+        ---
+        - hosts: {{.HOSTS}}
+          gather_facts: yes
+          tasks:
+            - name: Ping Linux hosts
+              ping:
+              when: ansible_facts.os_family != 'Windows'
 
-        # Check if we have Windows hosts
-        echo "Pinging Windows hosts..."
-        WIN_RESULT=0
-        WIN_HOSTS=$(ansible -i "{{.INVENTORY}}" -m win_ping {{.HOSTS}} 2>/dev/null | grep SUCCESS | awk '{print $1}' | tr -d ':' | tr '\n' ',')
-        if [ -n "$WIN_HOSTS" ]; then
-          echo "Successfully pinged Windows hosts: $WIN_HOSTS"
-        fi
+            - name: Ping Windows hosts
+              win_ping:
+              when: ansible_facts.os_family == 'Windows'
+        EOF
 
-        # Print combined successful results
         echo "===== PING RESULTS ====="
-        if [ -n "$LINUX_HOSTS" ]; then
-          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible -i "{{.INVENTORY}}" -m ping ${LINUX_HOSTS%,}
-        fi
+        {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}\
+          ansible-playbook -i "{{.INVENTORY}}" "$PLAYBOOK_FILE"
+        RET=$?
 
-        if [ -n "$WIN_HOSTS" ]; then
-          {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}ansible -i "{{.INVENTORY}}" -m win_ping ${WIN_HOSTS%,}
-        fi
-
-        # Check if we covered all hosts
-        SUCCESSFUL_HOSTS="$LINUX_HOSTS$WIN_HOSTS"
-        if [ -z "$SUCCESSFUL_HOSTS" ]; then
-          echo "ERROR: No hosts could be pinged with either ping or win_ping!"
-          exit 1
-        fi
-
-        # Always exit successfully if at least one host was pinged
-        exit 0
+        rm -f "$PLAYBOOK_FILE"
+        exit $RET
     silent: false
 
   run-molecule-tests:

--- a/ansible/Taskfile.yaml
+++ b/ansible/Taskfile.yaml
@@ -92,6 +92,29 @@ tasks:
         exit $RET
     silent: false
 
+  run-molecule-action:
+    desc: "Run GitHub Actions molecule workflow using act. Optionally specify ROLE or PLAYBOOK"
+    vars:
+      ROLE: '{{.ROLE | default ""}}'
+      PLAYBOOK: '{{.PLAYBOOK | default ""}}'
+      IS_MAC_ARM: '{{if and (eq OS "Darwin") (eq ARCH "arm64")}}true{{else}}false{{end}}'
+      ARCH_FLAG: '{{if eq .IS_MAC_ARM "true"}}--container-architecture linux/amd64{{end}}'
+    cmds:
+      - |
+        # Clean up any existing act containers
+        docker rm -f $(docker ps -q -f name=act-Molecule-Test) 2>/dev/null || true
+        if [ -n "{{.ROLE}}" ]; then
+          echo '{"inputs":{"ROLE":"{{.ROLE}}"}}' > /tmp/github-event.json
+          act -W .github/workflows/molecule.yaml {{.ARCH_FLAG}} -e /tmp/github-event.json
+          rm /tmp/github-event.json
+        elif [ -n "{{.PLAYBOOK}}" ]; then
+          echo '{"inputs":{"PLAYBOOK":"{{.PLAYBOOK}}"}}' > /tmp/github-event.json
+          act -W .github/workflows/molecule.yaml {{.ARCH_FLAG}} -e /tmp/github-event.json
+          rm /tmp/github-event.json
+        else
+          act -W .github/workflows/molecule.yaml {{.ARCH_FLAG}}
+        fi
+
   run-molecule-tests:
     desc: "Run Molecule tests for all roles"
     cmds:

--- a/ansible/Taskfile.yaml
+++ b/ansible/Taskfile.yaml
@@ -34,7 +34,7 @@ tasks:
     silent: true
 
   ping:
-    desc: "Ping: cross-OS, works on all/group/pattern/host specification, robust. Auto-detects Windows and Linux hosts."
+    desc: "Ping: cross-OS, works on all/group/pattern/host specification, robust. Auto-detects Windows, Linux, and macOS hosts."
     vars:
       INVENTORY: '{{.INVENTORY}}'
       HOSTS:     '{{.HOSTS | default "all"}}'
@@ -42,43 +42,53 @@ tasks:
       OS_TYPE:   '{{.OS_TYPE | default "auto"}}'
     cmds:
       - |
-        # Explicit OS_TYPE shortcuts
+        #— explicit OS_TYPE shortcuts
         if [ "{{.OS_TYPE}}" = "windows" ]; then
-          echo "Using win_ping module for all hosts (OS_TYPE=windows)"
+          echo "Using win_ping module for {{.HOSTS}} (OS_TYPE=windows)"
           {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}\
             ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m win_ping
           exit $?
         elif [ "{{.OS_TYPE}}" = "linux" ]; then
-          echo "Using ping module for all hosts (OS_TYPE=linux)"
+          echo "Using ping module for {{.HOSTS}} (OS_TYPE=linux)"
           {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}\
             ansible {{.HOSTS}} -i "{{.INVENTORY}}" -m ping
           exit $?
         fi
 
-        # Auto-detect & ping once per host via an inline playbook
-        echo "Auto-detecting host types and pinging each host…"
+        #— auto-detect: build a tiny playbook and run it
+        echo "Auto-detecting host types and pinging each…"
 
-        PLAYBOOK_FILE=$(mktemp /tmp/ping_playbook.XXXXXX.yml)
-        cat > "$PLAYBOOK_FILE" <<'EOF'
+        # try Linux-style mktemp first; if it errors, fall back to macOS -t form
+        if PLAYBOOK=$(mktemp /tmp/ping_playbook.XXXXXX.yml 2>/dev/null); then
+          :
+        else
+          PLAYBOOK=$(mktemp -t ping_playbook).yml
+        fi
+
+        cat > "$PLAYBOOK" << 'EOF'
         ---
         - hosts: {{.HOSTS}}
           gather_facts: yes
           tasks:
-            - name: Ping Linux hosts
-              ping:
-              when: ansible_facts.os_family != 'Windows'
-
             - name: Ping Windows hosts
               win_ping:
               when: ansible_facts.os_family == 'Windows'
+
+            - name: Ping macOS hosts
+              ping:
+              when: ansible_facts['system'] == 'Darwin'
+
+            - name: Ping Linux hosts
+              ping:
+              when: ansible_facts['system'] == 'Linux'
         EOF
 
         echo "===== PING RESULTS ====="
         {{if eq .DEBUG "false"}}ANSIBLE_PYTHON_INTERPRETER=auto_silent {{end}}\
-          ansible-playbook -i "{{.INVENTORY}}" "$PLAYBOOK_FILE"
+          ansible-playbook -i "{{.INVENTORY}}" "$PLAYBOOK"
         RET=$?
 
-        rm -f "$PLAYBOOK_FILE"
+        rm -f "$PLAYBOOK"
         exit $RET
     silent: false
 


### PR DESCRIPTION
**Key Changes:**

* Introduced a robust `ping` task for inventory validation across OS types.
* Automatically detects `os_family` via inline playbook fallback logic.
* Supports both explicit and automatic `OS_TYPE` selection.
* Restored `run-molecule-action` task using GitHub Actions + `act`, with ARM support.
* Updated documentation and task descriptions for clarity and usability.

**Added:**

* `ping` task to `Taskfile.yaml` supporting Windows, Linux, and macOS targets.
* Inline playbook for fact-based OS detection and module selection.
* `run-molecule-action` task with support for `ROLE`, `PLAYBOOK`, and macOS ARM.
* Cross-platform `mktemp` logic for temporary playbook generation.
* New README sections for `ping`, `lint-ansible`, and `run-molecule-action`.

**Changed:**

* Refined conditional command logic in `Taskfile.yaml`.
* Clarified README task descriptions with cleaner structure and examples.
* Improved ping output documentation with generic, OS-agnostic host examples.