### PR TITLE
feat: Add local and 1Password secret management taskfiles

### DIFF
--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,183 @@
+# 🔐 Secrets Taskfile Tasks
+
+Reusable Taskfile helpers for **secure secret management** with
+• 1Password CLI (`op`) – remote, team-ready vaults
+• sops + age – local, Git-friendly file encryption
+
+Works on macOS, Linux and Windows (WSL/PowerShell via Task).
+
+---
+
+## 📋 Prerequisites
+
+Global
+• [Task](https://taskfile.dev) ≥ v3
+• [jq](https://stedolan.github.io/jq) (optional but recommended for nicer JSON parsing)
+
+onepassword/ tasks
+• [1Password CLI](https://developer.1password.com/docs/cli/get-started)
+(`brew install --cask 1password/tap/1password-cli`)
+
+local/ tasks
+• [sops](https://github.com/mozilla/sops) (`brew install sops` / `apt …`)
+• [age](https://github.com/FiloSottile/age) (`brew install age` / `apt …`)
+
+---
+
+## 🎯 Available Tasks
+
+### onepassword/
+
+1. ensure-dependencies
+   Verify that `op` is on the PATH (auto-runs for every other task).
+
+1. setup-account
+   Add/sign-in to a 1Password account once per workstation.
+   Variables
+   • `OP_ACCOUNT` – your domain (default `my`).
+
+   ```bash
+   # first time
+   task onepassword:setup-account OP_ACCOUNT=my-team.1password.com
+   ```
+
+1. list-vaults
+
+   ```bash
+   task onepassword:list-vaults
+   ```
+
+1. list-secrets
+   List items with optional filters.
+   • `VAULT_NAME` – vault slug / UUID
+   • `CATEGORY` – Login, Password, API_Credential …
+
+   ```bash
+   task onepassword:list-secrets VAULT_NAME=Development CATEGORY=API_Credential
+   ```
+
+1. get-secret
+   Retrieve a field (defaults to a password) by item **name or UUID**.
+   Optional vars
+   • `VAULT` – vault slug / UUID
+   • `FIELD` – field label / ID / purpose (default `password`)
+   • `FORMAT` – `json|text` (fallback)
+   • `OUTPUT_FILE` – save to file instead of stdout
+
+   ```bash
+   # Print the password for “github-token” in vault “CI”
+   task onepassword:get-secret SECRET_NAME=github-token VAULT=CI
+
+   # Save an entire item as JSON for debugging
+   task onepassword:get-secret SECRET_NAME=abcd1234 OUTPUT_FILE=/tmp/item.json FORMAT=json
+   ```
+
+1. create-vault
+
+   ```bash
+   task onepassword:create-vault VAULT_NAME=Staging
+   ```
+
+---
+
+### local/
+
+1. ensure-dependencies
+   Guard against missing `sops` / `age`.
+
+1. create-age-keypair
+   Generates `~/.config/sops/age/keys.txt` (if absent) and prints the public key.
+
+   ```bash
+   task local:create-age-keypair
+   ```
+
+1. encrypt-file
+   Encrypt **YAML / any file** with sops-age.
+   Vars
+   • `INPUT_FILE` (required) – path of plaintext
+   • `OUTPUT_FILE` – override destination
+   • `AGE_FILE` – custom private key path
+   • `ENCRYPTED_REGEX` – only match keys (default covers common secret names)
+
+   ```bash
+   task local:encrypt-file INPUT_FILE=secrets.yaml
+   # → secrets.yaml.sops.yaml
+   ```
+
+1. decrypt-file
+   Vars
+   • `INPUT_FILE` (required) – encrypted file
+   • `OUTPUT_FILE` – plaintext destination (`*.dec` default)
+   • `AGE_FILE` – override key location
+
+   ```bash
+   task local:decrypt-file INPUT_FILE=secrets.yaml.sops.yaml
+   ```
+
+---
+
+## 🔍 Important Notes
+
+- All tasks exit early with helpful messages when prerequisites or input vars
+  are missing.
+- `get-secret` tries **three strategies** (field ID, field label, reference
+  path) before failing.
+- `encrypt-file` automatically builds the output filename (`.sops.yaml`) if
+  none is supplied.
+- `decrypt-file` respects `SOPS_AGE_KEY_FILE` or falls back to the generated
+  key.
+- No secrets are written to disk unless you supply `OUTPUT_FILE`.
+
+---
+
+## 🔧 Importing Into Your Project
+
+Task supports multiple included Taskfiles. Add to your root `Taskfile.yaml`:
+
+```yaml
+version: "3"
+includes:
+  secrets-onepassword: "./onepassword/Taskfile.yaml"
+  secrets-local: "./local/Taskfile.yaml"
+
+tasks:
+  bootstrap-secrets:
+    desc: "Ensure secrets tooling is ready"
+    cmds:
+      - task: secrets-onepassword:setup-account
+        vars: { OP_ACCOUNT: my-team.1password.com }
+      - task: secrets-local:create-age-keypair
+```
+
+Now run `task bootstrap-secrets` from anywhere in your repo.
+
+---
+
+## 📝 Directory Layout
+
+```text
+.
+├── onepassword/
+│   └── Taskfile.yaml   # 1Password helpers
+├── local/
+│   └── Taskfile.yaml   # sops-age helpers
+└── README.md           # (this file)
+```
+
+---
+
+## 🤝 Contributing
+
+1. Fork & branch.
+1. Add/adjust tasks – keep them idempotent and cross-platform.
+1. `task secrets-onepassword:ensure-dependencies` and
+   `task secrets-local:ensure-dependencies` must pass.
+1. Document any new variables in this README.
+1. Open a PR – GitHub Actions will lint and test.
+
+---
+
+## 📜 License
+
+MIT – see `LICENSE` for details.

--- a/secrets/Taskfile.yaml
+++ b/secrets/Taskfile.yaml
@@ -1,0 +1,35 @@
+---
+version: "3"
+
+includes:
+  onepassword: ./onepassword/Taskfile.yaml
+  local: ./local/Taskfile.yaml
+
+tasks:
+  default:
+    desc: "List available secret management tasks"
+    cmds:
+      - |
+        echo "Secret Management Tasks"
+        echo "======================="
+        echo "This Taskfile provides tools for managing secrets using either:"
+        echo "  - Local encryption with SOPS and Age"
+        echo "  - 1Password"
+        echo ""
+        echo "Available commands:"
+        echo "  task local:<cmd>         - Local encryption commands with SOPS/Age"
+        echo "    task local:create-age-keypair - Generate a new Age keypair"
+        echo "    task local:encrypt-file      - Encrypt a file with SOPS/Age"
+        echo "    task local:decrypt-file      - Decrypt a file with SOPS/Age"
+        echo ""
+        echo "  task onepassword:<cmd>   - 1Password commands"
+        echo "    task onepassword:setup-account  - Set up 1Password CLI"
+        echo "    task onepassword:create-vault   - Create a new 1Password vault"
+        echo "    task onepassword:store-secret   - Store a secret in 1Password"
+        echo "    task onepassword:get-secret     - Retrieve a secret from 1Password"
+        echo "    task onepassword:encrypt-file   - Encrypt a file with 1Password"
+        echo "    task onepassword:decrypt-file   - Decrypt a file from 1Password"
+        echo "    task onepassword:delete-secret  - Delete a secret from 1Password"
+        echo "    task onepassword:list-secrets   - List secrets in a vault"
+        echo ""
+        echo "For more details, run: task -l"

--- a/secrets/local/Taskfile.yaml
+++ b/secrets/local/Taskfile.yaml
@@ -1,0 +1,116 @@
+---
+version: "3"
+
+tasks:
+  ensure-dependencies:
+    desc: "Verify that sops and age are installed"
+    cmds:
+      - |
+        if ! command -v sops &> /dev/null; then
+          echo "'sops' command not found. Please install sops: https://github.com/mozilla/sops"
+          exit 1
+        fi
+        if ! command -v age &> /dev/null; then
+          echo "'age' command not found. Please install age: https://github.com/FiloSottile/age"
+          exit 1
+        fi
+
+  create-age-keypair:
+    desc: "Generate a new age keypair and save it to ~/.config/sops/age/keys.txt"
+    deps:
+      - ensure-dependencies
+    vars:
+      AGE_DIR: "{{.AGE_DIR | default \"$HOME/.config/sops/age\"}}"
+      AGE_FILE: "{{.AGE_FILE | default \"$HOME/.config/sops/age/keys.txt\"}}"
+    cmds:
+      - |
+        # Ensure the age directory exists
+        mkdir -p "{{.AGE_DIR}}"
+
+        # Generate a new age keypair
+        age-keygen -o "{{.AGE_FILE}}"
+
+        echo "Age keypair generated and saved to {{.AGE_FILE}}"
+        echo "Your public key is:"
+        grep "^# public key: " "{{.AGE_FILE}}" | sed 's/# public key: //'
+
+  encrypt-file:
+    desc: "Encrypt a file using sops with age"
+    deps:
+      - ensure-dependencies
+    vars:
+      AGE_FILE: "{{.AGE_FILE | default \"$HOME/.config/sops/age/keys.txt\"}}"
+      INPUT_FILE: "{{.INPUT_FILE | default \"\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+      ENCRYPTED_REGEX: "{{.ENCRYPTED_REGEX | default \"(age_key|allowed_cidrs|cloudflare|porkbun|tailscale|goad|individual|opensearch)\"}}"
+    cmds:
+      - |
+        # Check if age key exists
+        KEY_FILE="{{.AGE_FILE}}"
+        if [ ! -f "$KEY_FILE" ]; then
+          echo "Age key not found at $KEY_FILE. Please run 'task create-age-keypair' first."
+          exit 1
+        fi
+        # Ensure INPUT_FILE is provided
+        if [ -z "{{.INPUT_FILE}}" ]; then
+          echo "Please specify the input file to encrypt using the INPUT_FILE variable."
+          exit 1
+        fi
+        # Expand the tilde in input path
+        INPUT_PATH=$(eval echo "{{.INPUT_FILE}}")
+
+        # Set OUTPUT_FILE if not provided
+        if [ -z "{{.OUTPUT_FILE}}" ]; then
+          OUTPUT_FILE="${INPUT_PATH%.dec}"
+          if [[ "$OUTPUT_FILE" == "$INPUT_PATH" ]]; then
+            OUTPUT_FILE="${INPUT_PATH}.sops.yaml"
+          fi
+        else
+          OUTPUT_FILE=$(eval echo "{{.OUTPUT_FILE}}")
+        fi
+        # Get the public key
+        PUBLIC_KEY=$(grep "^# public key: " "$KEY_FILE" | sed 's/# public key: //')
+
+        # Encrypt the file using sops with explicit age key and encrypted regex
+        # Remove --in-place flag since we're using a separate output file
+        sops --encrypt --age="$PUBLIC_KEY" --encrypted-regex="{{.ENCRYPTED_REGEX}}" "$INPUT_PATH" > "$OUTPUT_FILE"
+        echo "Encrypted file saved to $OUTPUT_FILE"
+
+  decrypt-file:
+    desc: "Decrypt a file using sops with age"
+    deps:
+      - ensure-dependencies
+    vars:
+      AGE_FILE: "{{.AGE_FILE | default (env \"SOPS_AGE_KEY_FILE\" | default \"$HOME/.config/sops/age/keys.txt\")}}"
+      INPUT_FILE: "{{.INPUT_FILE | default \"\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+    cmds:
+      - |
+        # Check if age key exists
+        KEY_FILE="{{.AGE_FILE}}"
+        if [ ! -f "$KEY_FILE" ]; then
+          echo "Age key not found at $KEY_FILE. Please run 'task create-age-keypair' first."
+          exit 1
+        fi
+
+        # Ensure INPUT_FILE is provided
+        if [ -z "{{.INPUT_FILE}}" ]; then
+          echo "Please specify the input file to decrypt using the INPUT_FILE variable."
+          exit 1
+        fi
+
+        # Expand the tilde in input path
+        INPUT_PATH=$(eval echo "{{.INPUT_FILE}}")
+
+        # Set OUTPUT_FILE if not provided
+        if [ -z "{{.OUTPUT_FILE}}" ]; then
+          OUTPUT_FILE="${INPUT_PATH}.dec"
+        else
+          OUTPUT_FILE=$(eval echo "{{.OUTPUT_FILE}}")
+        fi
+
+        # Decrypt the file using sops
+        export SOPS_AGE_KEY_FILE="$KEY_FILE"
+        sops -d "$INPUT_PATH" > "$OUTPUT_FILE"
+
+        echo "Decrypted file saved to $OUTPUT_FILE"

--- a/secrets/onepassword/Taskfile.yaml
+++ b/secrets/onepassword/Taskfile.yaml
@@ -264,3 +264,169 @@ tasks:
         op vault create "{{.VAULT_NAME}}"
 
         echo "Vault '{{.VAULT_NAME}}' created successfully."
+
+  # TODO: WIP
+  # store-secret:
+  #   desc: "Store a secret in 1Password"
+  #   deps:
+  #     - ensure-dependencies
+  #   vars:
+  #     SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
+  #     SECRET_VALUE: "{{.SECRET_VALUE | default \"\"}}"
+  #     VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+  #     SECRET_CATEGORY: "{{.SECRET_CATEGORY | default \"Password\"}}"
+  #     SECRET_NOTES: "{{.SECRET_NOTES | default \"\"}}"
+  #   cmds:
+  #     - |
+  #       # Check required parameters
+  #       if [ -z "{{.SECRET_NAME}}" ]; then
+  #         echo "Please specify the secret name using the SECRET_NAME variable."
+  #         exit 1
+  #       fi
+
+  #       if [ -z "{{.VAULT_NAME}}" ]; then
+  #         echo "Please specify the vault name using the VAULT_NAME variable."
+  #         exit 1
+  #       fi
+
+  #       # Check if we should read from stdin
+  #       if [ -z "{{.SECRET_VALUE}}" ]; then
+  #         echo "Enter the secret value (input will be hidden):"
+  #         read -s SECRET_VALUE
+  #         echo ""  # Add a newline after hidden input
+  #       else
+  #         SECRET_VALUE="{{.SECRET_VALUE}}"
+  #       fi
+
+  #       # Store the secret
+  #       op item create \
+  #         --category="{{.SECRET_CATEGORY}}" \
+  #         --title="{{.SECRET_NAME}}" \
+  #         --vault="{{.VAULT_NAME}}" \
+  #         --notes="{{.SECRET_NOTES}}" \
+  #         password="$SECRET_VALUE"
+
+  #       echo "Secret '{{.SECRET_NAME}}' stored in vault '{{.VAULT_NAME}}'"
+
+  # encrypt-file:
+  #   desc: "Encrypt a file using 1Password"
+  #   deps:
+  #     - ensure-dependencies
+  #   vars:
+  #     INPUT_FILE: "{{.INPUT_FILE | default \"\"}}"
+  #     OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+  #     VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+  #     DOCUMENT_TITLE: "{{.DOCUMENT_TITLE | default \"\"}}"
+  #   cmds:
+  #     - |
+  #       # Ensure INPUT_FILE is provided
+  #       if [ -z "{{.INPUT_FILE}}" ]; then
+  #         echo "Please specify the input file to encrypt using the INPUT_FILE variable."
+  #         exit 1
+  #       fi
+
+  #       # Expand the tilde in input path
+  #       INPUT_PATH=$(eval echo "{{.INPUT_FILE}}")
+
+  #       # Set document title if not provided
+  #       if [ -z "{{.DOCUMENT_TITLE}}" ]; then
+  #         DOCUMENT_TITLE=$(basename "$INPUT_PATH")
+  #       else
+  #         DOCUMENT_TITLE="{{.DOCUMENT_TITLE}}"
+  #       fi
+
+  #       # Prepare vault filter if provided
+  #       VAULT_FILTER=""
+  #       if [ -n "{{.VAULT_NAME}}" ]; then
+  #         VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+  #       fi
+
+  #       # Store the file in 1Password
+  #       eval "op document create \"$INPUT_PATH\" --title=\"$DOCUMENT_TITLE\" $VAULT_FILTER"
+
+  #       # If OUTPUT_FILE is specified, also create a .op reference file
+  #       if [ -n "{{.OUTPUT_FILE}}" ]; then
+  #         OUTPUT_PATH=$(eval echo "{{.OUTPUT_FILE}}")
+  #         echo "# This file is stored in 1Password" > "$OUTPUT_PATH"
+  #         echo "# Title: $DOCUMENT_TITLE" >> "$OUTPUT_PATH"
+  #         echo "# To retrieve: task decrypt-file DOCUMENT_TITLE=\"$DOCUMENT_TITLE\"" >> "$OUTPUT_PATH"
+  #         echo "File encrypted and reference saved to $OUTPUT_PATH"
+  #       fi
+
+  # decrypt-file:
+  #   desc: "Decrypt a file from 1Password"
+  #   deps:
+  #     - ensure-dependencies
+  #   vars:
+  #     DOCUMENT_TITLE: "{{.DOCUMENT_TITLE | default \"\"}}"
+  #     DOCUMENT_ID: "{{.DOCUMENT_ID | default \"\"}}"
+  #     OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+  #     VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+  #   cmds:
+  #     - |
+  #       # Ensure either DOCUMENT_TITLE or DOCUMENT_ID is provided
+  #       if [ -z "{{.DOCUMENT_TITLE}}" ] && [ -z "{{.DOCUMENT_ID}}" ]; then
+  #         echo "Please specify either the document title using DOCUMENT_TITLE or the document ID using DOCUMENT_ID."
+  #         exit 1
+  #       fi
+
+  #       # Prepare vault filter if provided
+  #       VAULT_FILTER=""
+  #       if [ -n "{{.VAULT_NAME}}" ]; then
+  #         VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+  #       fi
+
+  #       # Set identifier based on what was provided
+  #       if [ -n "{{.DOCUMENT_TITLE}}" ]; then
+  #         IDENTIFIER="{{.DOCUMENT_TITLE}}"
+  #       else
+  #         IDENTIFIER="{{.DOCUMENT_ID}}"
+  #       fi
+
+  #       # Set OUTPUT_FILE if not provided
+  #       if [ -z "{{.OUTPUT_FILE}}" ]; then
+  #         if [ -n "{{.DOCUMENT_TITLE}}" ]; then
+  #           OUTPUT_FILE="{{.DOCUMENT_TITLE}}"
+  #         else
+  #           OUTPUT_FILE="document_from_1password"
+  #         fi
+  #       else
+  #         OUTPUT_FILE=$(eval echo "{{.OUTPUT_FILE}}")
+  #       fi
+
+  #       # Retrieve the document from 1Password
+  #       eval "op document get \"$IDENTIFIER\" $VAULT_FILTER --output=\"$OUTPUT_FILE\""
+
+  #       echo "Document retrieved and saved to $OUTPUT_FILE"
+
+  # delete-secret:
+  #   desc: "Delete a secret from 1Password"
+  #   deps:
+  #     - ensure-dependencies
+  #   vars:
+  #     SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
+  #     VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+  #   cmds:
+  #     - |
+  #       # Check required parameters
+  #       if [ -z "{{.SECRET_NAME}}" ]; then
+  #         echo "Please specify the secret name using the SECRET_NAME variable."
+  #         exit 1
+  #       fi
+
+  #       # Prepare vault filter if provided
+  #       VAULT_FILTER=""
+  #       if [ -n "{{.VAULT_NAME}}" ]; then
+  #         VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+  #       fi
+
+  #       # Ask for confirmation
+  #       read -p "Are you sure you want to delete '{{.SECRET_NAME}}'? (y/N) " -n 1 -r
+  #       echo    # Move to a new line
+  #       if [[ $REPLY =~ ^[Yy]$ ]]; then
+  #         # Delete the secret
+  #         eval "op item delete \"{{.SECRET_NAME}}\" $VAULT_FILTER"
+  #         echo "Secret '{{.SECRET_NAME}}' deleted."
+  #       else
+  #         echo "Operation cancelled."
+  #       fi

--- a/secrets/onepassword/Taskfile.yaml
+++ b/secrets/onepassword/Taskfile.yaml
@@ -1,0 +1,296 @@
+---
+version: "3"
+
+tasks:
+  ensure-dependencies:
+    desc: "Verify that 1Password CLI is installed"
+    cmds:
+      - |
+        if ! command -v op &> /dev/null; then
+          echo "'op' command not found. Please install 1Password CLI: https://developer.1password.com/docs/cli/get-started"
+          exit 1
+        fi
+
+  setup-account:
+    desc: "Set up 1Password CLI and authenticate with your account"
+    deps:
+      - ensure-dependencies
+    vars:
+      OP_ACCOUNT: "{{.OP_ACCOUNT | default \"my\"}}"
+    cmds:
+      - |
+        # Ensure the op config directory exists
+        mkdir -p "${HOME}/.config/op"
+
+        # Check if we have an account specified
+        if [ -z "{{.OP_ACCOUNT}}" ]; then
+          echo "Please specify your 1Password account domain using the OP_ACCOUNT variable."
+          echo "Example: task setup-account OP_ACCOUNT=my-team.1password.com"
+          exit 1
+        fi
+
+        # Check if already signed in by using 'op whoami'
+        if user_info=$(op whoami --account "{{.OP_ACCOUNT}}" 2>/dev/null); then
+          # Extract email from whoami output
+          email=$(echo "$user_info" | grep "Email:" | awk '{print $2}')
+
+          echo "✅ Already signed in to 1Password account {{.OP_ACCOUNT}}"
+          echo "   Account email: $email"
+          echo "   Your 1Password CLI is ready to use"
+        else
+          # Sign in to 1Password account
+          echo "Setting up 1Password CLI with account {{.OP_ACCOUNT}}"
+          op account add --address "{{.OP_ACCOUNT}}"
+
+          echo "✅ 1Password account setup complete."
+          echo "   Use 'op signin' to authenticate your session."
+          echo "   To verify your setup, run: op whoami"
+        fi
+
+  create-vault:
+    desc: "Create a new vault in 1Password"
+    deps:
+      - ensure-dependencies
+    cmds:
+      - |
+        # Ensure VAULT_NAME is provided
+        if [ -z "{{.VAULT_NAME}}" ]; then
+          echo "Please specify the vault name using the VAULT_NAME variable."
+          echo "Example: task create-vault VAULT_NAME=Development"
+          exit 1
+        fi
+
+        # Create the vault
+        echo "Creating new vault named '{{.VAULT_NAME}}'"
+        op vault create "{{.VAULT_NAME}}"
+
+        echo "Vault '{{.VAULT_NAME}}' created successfully."
+
+  list-vaults:
+    desc: "List all vaults in your 1Password account"
+    deps:
+      - ensure-dependencies
+    cmds:
+      - op vault list
+
+  store-secret:
+    desc: "Store a secret in 1Password"
+    deps:
+      - ensure-dependencies
+    vars:
+      SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
+      SECRET_VALUE: "{{.SECRET_VALUE | default \"\"}}"
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+      SECRET_CATEGORY: "{{.SECRET_CATEGORY | default \"Password\"}}"
+      SECRET_NOTES: "{{.SECRET_NOTES | default \"\"}}"
+    cmds:
+      - |
+        # Check required parameters
+        if [ -z "{{.SECRET_NAME}}" ]; then
+          echo "Please specify the secret name using the SECRET_NAME variable."
+          exit 1
+        fi
+
+        if [ -z "{{.VAULT_NAME}}" ]; then
+          echo "Please specify the vault name using the VAULT_NAME variable."
+          exit 1
+        fi
+
+        # Check if we should read from stdin
+        if [ -z "{{.SECRET_VALUE}}" ]; then
+          echo "Enter the secret value (input will be hidden):"
+          read -s SECRET_VALUE
+          echo ""  # Add a newline after hidden input
+        else
+          SECRET_VALUE="{{.SECRET_VALUE}}"
+        fi
+
+        # Store the secret
+        op item create \
+          --category="{{.SECRET_CATEGORY}}" \
+          --title="{{.SECRET_NAME}}" \
+          --vault="{{.VAULT_NAME}}" \
+          --notes="{{.SECRET_NOTES}}" \
+          password="$SECRET_VALUE"
+
+        echo "Secret '{{.SECRET_NAME}}' stored in vault '{{.VAULT_NAME}}'"
+
+  get-secret:
+    desc: "Retrieve a secret from 1Password"
+    deps:
+      - ensure-dependencies
+    vars:
+      SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+    cmds:
+      - |
+        # Check required parameters
+        if [ -z "{{.SECRET_NAME}}" ]; then
+          echo "Please specify the secret name using the SECRET_NAME variable."
+          exit 1
+        fi
+
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT_NAME}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+        fi
+
+        # Retrieve the secret
+        if [ -z "{{.OUTPUT_FILE}}" ]; then
+          # Display to terminal
+          eval "op item get \"{{.SECRET_NAME}}\" $VAULT_FILTER --fields password"
+        else
+          # Save to file
+          OUTPUT_PATH=$(eval echo "{{.OUTPUT_FILE}}")
+          eval "op item get \"{{.SECRET_NAME}}\" $VAULT_FILTER --fields password" > "$OUTPUT_PATH"
+          echo "Secret '{{.SECRET_NAME}}' saved to $OUTPUT_PATH"
+        fi
+
+  encrypt-file:
+    desc: "Encrypt a file using 1Password"
+    deps:
+      - ensure-dependencies
+    vars:
+      INPUT_FILE: "{{.INPUT_FILE | default \"\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+      DOCUMENT_TITLE: "{{.DOCUMENT_TITLE | default \"\"}}"
+    cmds:
+      - |
+        # Ensure INPUT_FILE is provided
+        if [ -z "{{.INPUT_FILE}}" ]; then
+          echo "Please specify the input file to encrypt using the INPUT_FILE variable."
+          exit 1
+        fi
+
+        # Expand the tilde in input path
+        INPUT_PATH=$(eval echo "{{.INPUT_FILE}}")
+
+        # Set document title if not provided
+        if [ -z "{{.DOCUMENT_TITLE}}" ]; then
+          DOCUMENT_TITLE=$(basename "$INPUT_PATH")
+        else
+          DOCUMENT_TITLE="{{.DOCUMENT_TITLE}}"
+        fi
+
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT_NAME}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+        fi
+
+        # Store the file in 1Password
+        eval "op document create \"$INPUT_PATH\" --title=\"$DOCUMENT_TITLE\" $VAULT_FILTER"
+
+        # If OUTPUT_FILE is specified, also create a .op reference file
+        if [ -n "{{.OUTPUT_FILE}}" ]; then
+          OUTPUT_PATH=$(eval echo "{{.OUTPUT_FILE}}")
+          echo "# This file is stored in 1Password" > "$OUTPUT_PATH"
+          echo "# Title: $DOCUMENT_TITLE" >> "$OUTPUT_PATH"
+          echo "# To retrieve: task decrypt-file DOCUMENT_TITLE=\"$DOCUMENT_TITLE\"" >> "$OUTPUT_PATH"
+          echo "File encrypted and reference saved to $OUTPUT_PATH"
+        fi
+
+  decrypt-file:
+    desc: "Decrypt a file from 1Password"
+    deps:
+      - ensure-dependencies
+    vars:
+      DOCUMENT_TITLE: "{{.DOCUMENT_TITLE | default \"\"}}"
+      DOCUMENT_ID: "{{.DOCUMENT_ID | default \"\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+    cmds:
+      - |
+        # Ensure either DOCUMENT_TITLE or DOCUMENT_ID is provided
+        if [ -z "{{.DOCUMENT_TITLE}}" ] && [ -z "{{.DOCUMENT_ID}}" ]; then
+          echo "Please specify either the document title using DOCUMENT_TITLE or the document ID using DOCUMENT_ID."
+          exit 1
+        fi
+
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT_NAME}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+        fi
+
+        # Set identifier based on what was provided
+        if [ -n "{{.DOCUMENT_TITLE}}" ]; then
+          IDENTIFIER="{{.DOCUMENT_TITLE}}"
+        else
+          IDENTIFIER="{{.DOCUMENT_ID}}"
+        fi
+
+        # Set OUTPUT_FILE if not provided
+        if [ -z "{{.OUTPUT_FILE}}" ]; then
+          if [ -n "{{.DOCUMENT_TITLE}}" ]; then
+            OUTPUT_FILE="{{.DOCUMENT_TITLE}}"
+          else
+            OUTPUT_FILE="document_from_1password"
+          fi
+        else
+          OUTPUT_FILE=$(eval echo "{{.OUTPUT_FILE}}")
+        fi
+
+        # Retrieve the document from 1Password
+        eval "op document get \"$IDENTIFIER\" $VAULT_FILTER --output=\"$OUTPUT_FILE\""
+
+        echo "Document retrieved and saved to $OUTPUT_FILE"
+
+  delete-secret:
+    desc: "Delete a secret from 1Password"
+    deps:
+      - ensure-dependencies
+    vars:
+      SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+    cmds:
+      - |
+        # Check required parameters
+        if [ -z "{{.SECRET_NAME}}" ]; then
+          echo "Please specify the secret name using the SECRET_NAME variable."
+          exit 1
+        fi
+
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT_NAME}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+        fi
+
+        # Ask for confirmation
+        read -p "Are you sure you want to delete '{{.SECRET_NAME}}'? (y/N) " -n 1 -r
+        echo    # Move to a new line
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+          # Delete the secret
+          eval "op item delete \"{{.SECRET_NAME}}\" $VAULT_FILTER"
+          echo "Secret '{{.SECRET_NAME}}' deleted."
+        else
+          echo "Operation cancelled."
+        fi
+
+  list-secrets:
+    desc: "List secrets in a vault"
+    deps:
+      - ensure-dependencies
+    vars:
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+      CATEGORY: "{{.CATEGORY | default \"\"}}"
+    cmds:
+      - |
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT_NAME}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+        fi
+
+        # Prepare category filter if provided
+        CATEGORY_FILTER=""
+        if [ -n "{{.CATEGORY}}" ]; then
+          CATEGORY_FILTER="--categories=\"{{.CATEGORY}}\""
+        fi
+
+        # List the items
+        eval "op item list $VAULT_FILTER $CATEGORY_FILTER"

--- a/secrets/onepassword/Taskfile.yaml
+++ b/secrets/onepassword/Taskfile.yaml
@@ -54,6 +54,30 @@ tasks:
     cmds:
       - op vault list
 
+  list-secrets:
+    desc: "List secrets in a vault"
+    deps:
+      - ensure-dependencies
+    vars:
+      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
+      CATEGORY: "{{.CATEGORY | default \"\"}}"
+    cmds:
+      - |
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT_NAME}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
+        fi
+
+        # Prepare category filter if provided
+        CATEGORY_FILTER=""
+        if [ -n "{{.CATEGORY}}" ]; then
+          CATEGORY_FILTER="--categories=\"{{.CATEGORY}}\""
+        fi
+
+        # List the items
+        eval "op item list $VAULT_FILTER $CATEGORY_FILTER"
+
   get-secret:
     desc: "Retrieve a secret from 1Password (by ID or name)"
     deps:
@@ -152,7 +176,7 @@ tasks:
             # Method 1: Get by item ID and field ID directly
             if [ "$JQ_AVAILABLE" = true ] && [ -n "$PASSWORD_ID" ]; then
               echo "📤 Trying to get password by item ID and field ID..."
-              SECRET_VALUE=$(op item get "$ITEM_ID" --fields "$PASSWORD_ID" 2>/dev/null)
+              SECRET_VALUE=$(op item get "$ITEM_ID" --fields "$PASSWORD_ID" --reveal 2>/dev/null)
               if [ $? -eq 0 ] && [ -n "$SECRET_VALUE" ]; then
                 echo "✅ Secret retrieved successfully (Method 1)"
                 echo "$SECRET_VALUE"
@@ -162,7 +186,7 @@ tasks:
 
             # Method 2: Get by item ID and field label
             echo "📤 Trying to get password by item ID and field label..."
-            SECRET_VALUE=$(op item get "$ITEM_ID" --fields "$PASSWORD_FIELD" 2>/dev/null)
+            SECRET_VALUE=$(op item get "$ITEM_ID" --fields "$PASSWORD_FIELD" --reveal 2>/dev/null)
             if [ $? -eq 0 ] && [ -n "$SECRET_VALUE" ]; then
               echo "✅ Secret retrieved successfully (Method 2)"
               echo "$SECRET_VALUE"
@@ -174,7 +198,7 @@ tasks:
               REF_PATH=$(echo "$ITEM_INFO" | jq -r --arg field "$PASSWORD_FIELD" '.fields[] | select(.id==$field or .label==$field) | .reference')
               if [ -n "$REF_PATH" ] && [ "$REF_PATH" != "null" ]; then
                 echo "📤 Trying to get password using reference path: $REF_PATH"
-                SECRET_VALUE=$(op read "$REF_PATH" 2>/dev/null)
+                SECRET_VALUE=$(op read "$REF_PATH" --reveal 2>/dev/null)
                 if [ $? -eq 0 ] && [ -n "$SECRET_VALUE" ]; then
                   echo "✅ Secret retrieved successfully (Method 3)"
                   echo "$SECRET_VALUE"
@@ -186,11 +210,11 @@ tasks:
             # Method 4: Last resort - try to get the entire item and parse manually
             echo "📤 Trying alternative method to get password..."
             if [ "$FORMAT" = "text" ]; then
-              op item get "$ITEM_ID" --format="$FORMAT"
+              op item get "$ITEM_ID" --format="$FORMAT" --reveal
               exit $?
             else
               # Try to get all fields as JSON and parse later
-              op item get "$ITEM_ID"
+              op item get "$ITEM_ID" --reveal
               exit $?
             fi
           else
@@ -240,192 +264,3 @@ tasks:
         op vault create "{{.VAULT_NAME}}"
 
         echo "Vault '{{.VAULT_NAME}}' created successfully."
-
-  store-secret:
-    desc: "Store a secret in 1Password"
-    deps:
-      - ensure-dependencies
-    vars:
-      SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
-      SECRET_VALUE: "{{.SECRET_VALUE | default \"\"}}"
-      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
-      SECRET_CATEGORY: "{{.SECRET_CATEGORY | default \"Password\"}}"
-      SECRET_NOTES: "{{.SECRET_NOTES | default \"\"}}"
-    cmds:
-      - |
-        # Check required parameters
-        if [ -z "{{.SECRET_NAME}}" ]; then
-          echo "Please specify the secret name using the SECRET_NAME variable."
-          exit 1
-        fi
-
-        if [ -z "{{.VAULT_NAME}}" ]; then
-          echo "Please specify the vault name using the VAULT_NAME variable."
-          exit 1
-        fi
-
-        # Check if we should read from stdin
-        if [ -z "{{.SECRET_VALUE}}" ]; then
-          echo "Enter the secret value (input will be hidden):"
-          read -s SECRET_VALUE
-          echo ""  # Add a newline after hidden input
-        else
-          SECRET_VALUE="{{.SECRET_VALUE}}"
-        fi
-
-        # Store the secret
-        op item create \
-          --category="{{.SECRET_CATEGORY}}" \
-          --title="{{.SECRET_NAME}}" \
-          --vault="{{.VAULT_NAME}}" \
-          --notes="{{.SECRET_NOTES}}" \
-          password="$SECRET_VALUE"
-
-        echo "Secret '{{.SECRET_NAME}}' stored in vault '{{.VAULT_NAME}}'"
-
-  encrypt-file:
-    desc: "Encrypt a file using 1Password"
-    deps:
-      - ensure-dependencies
-    vars:
-      INPUT_FILE: "{{.INPUT_FILE | default \"\"}}"
-      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
-      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
-      DOCUMENT_TITLE: "{{.DOCUMENT_TITLE | default \"\"}}"
-    cmds:
-      - |
-        # Ensure INPUT_FILE is provided
-        if [ -z "{{.INPUT_FILE}}" ]; then
-          echo "Please specify the input file to encrypt using the INPUT_FILE variable."
-          exit 1
-        fi
-
-        # Expand the tilde in input path
-        INPUT_PATH=$(eval echo "{{.INPUT_FILE}}")
-
-        # Set document title if not provided
-        if [ -z "{{.DOCUMENT_TITLE}}" ]; then
-          DOCUMENT_TITLE=$(basename "$INPUT_PATH")
-        else
-          DOCUMENT_TITLE="{{.DOCUMENT_TITLE}}"
-        fi
-
-        # Prepare vault filter if provided
-        VAULT_FILTER=""
-        if [ -n "{{.VAULT_NAME}}" ]; then
-          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
-        fi
-
-        # Store the file in 1Password
-        eval "op document create \"$INPUT_PATH\" --title=\"$DOCUMENT_TITLE\" $VAULT_FILTER"
-
-        # If OUTPUT_FILE is specified, also create a .op reference file
-        if [ -n "{{.OUTPUT_FILE}}" ]; then
-          OUTPUT_PATH=$(eval echo "{{.OUTPUT_FILE}}")
-          echo "# This file is stored in 1Password" > "$OUTPUT_PATH"
-          echo "# Title: $DOCUMENT_TITLE" >> "$OUTPUT_PATH"
-          echo "# To retrieve: task decrypt-file DOCUMENT_TITLE=\"$DOCUMENT_TITLE\"" >> "$OUTPUT_PATH"
-          echo "File encrypted and reference saved to $OUTPUT_PATH"
-        fi
-
-  decrypt-file:
-    desc: "Decrypt a file from 1Password"
-    deps:
-      - ensure-dependencies
-    vars:
-      DOCUMENT_TITLE: "{{.DOCUMENT_TITLE | default \"\"}}"
-      DOCUMENT_ID: "{{.DOCUMENT_ID | default \"\"}}"
-      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
-      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
-    cmds:
-      - |
-        # Ensure either DOCUMENT_TITLE or DOCUMENT_ID is provided
-        if [ -z "{{.DOCUMENT_TITLE}}" ] && [ -z "{{.DOCUMENT_ID}}" ]; then
-          echo "Please specify either the document title using DOCUMENT_TITLE or the document ID using DOCUMENT_ID."
-          exit 1
-        fi
-
-        # Prepare vault filter if provided
-        VAULT_FILTER=""
-        if [ -n "{{.VAULT_NAME}}" ]; then
-          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
-        fi
-
-        # Set identifier based on what was provided
-        if [ -n "{{.DOCUMENT_TITLE}}" ]; then
-          IDENTIFIER="{{.DOCUMENT_TITLE}}"
-        else
-          IDENTIFIER="{{.DOCUMENT_ID}}"
-        fi
-
-        # Set OUTPUT_FILE if not provided
-        if [ -z "{{.OUTPUT_FILE}}" ]; then
-          if [ -n "{{.DOCUMENT_TITLE}}" ]; then
-            OUTPUT_FILE="{{.DOCUMENT_TITLE}}"
-          else
-            OUTPUT_FILE="document_from_1password"
-          fi
-        else
-          OUTPUT_FILE=$(eval echo "{{.OUTPUT_FILE}}")
-        fi
-
-        # Retrieve the document from 1Password
-        eval "op document get \"$IDENTIFIER\" $VAULT_FILTER --output=\"$OUTPUT_FILE\""
-
-        echo "Document retrieved and saved to $OUTPUT_FILE"
-
-  delete-secret:
-    desc: "Delete a secret from 1Password"
-    deps:
-      - ensure-dependencies
-    vars:
-      SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
-      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
-    cmds:
-      - |
-        # Check required parameters
-        if [ -z "{{.SECRET_NAME}}" ]; then
-          echo "Please specify the secret name using the SECRET_NAME variable."
-          exit 1
-        fi
-
-        # Prepare vault filter if provided
-        VAULT_FILTER=""
-        if [ -n "{{.VAULT_NAME}}" ]; then
-          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
-        fi
-
-        # Ask for confirmation
-        read -p "Are you sure you want to delete '{{.SECRET_NAME}}'? (y/N) " -n 1 -r
-        echo    # Move to a new line
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-          # Delete the secret
-          eval "op item delete \"{{.SECRET_NAME}}\" $VAULT_FILTER"
-          echo "Secret '{{.SECRET_NAME}}' deleted."
-        else
-          echo "Operation cancelled."
-        fi
-
-  list-secrets:
-    desc: "List secrets in a vault"
-    deps:
-      - ensure-dependencies
-    vars:
-      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
-      CATEGORY: "{{.CATEGORY | default \"\"}}"
-    cmds:
-      - |
-        # Prepare vault filter if provided
-        VAULT_FILTER=""
-        if [ -n "{{.VAULT_NAME}}" ]; then
-          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
-        fi
-
-        # Prepare category filter if provided
-        CATEGORY_FILTER=""
-        if [ -n "{{.CATEGORY}}" ]; then
-          CATEGORY_FILTER="--categories=\"{{.CATEGORY}}\""
-        fi
-
-        # List the items
-        eval "op item list $VAULT_FILTER $CATEGORY_FILTER"

--- a/secrets/onepassword/Taskfile.yaml
+++ b/secrets/onepassword/Taskfile.yaml
@@ -47,6 +47,181 @@ tasks:
           echo "   To verify your setup, run: op whoami"
         fi
 
+  list-vaults:
+    desc: "List all vaults in your 1Password account"
+    deps:
+      - ensure-dependencies
+    cmds:
+      - op vault list
+
+  get-secret:
+    desc: "Retrieve a secret from 1Password (by ID or name)"
+    deps:
+      - ensure-dependencies
+    cmds:
+      - |
+        # Check required parameters
+        if [ -z "{{.SECRET_NAME}}" ]; then
+          echo "Please specify the secret name using the SECRET_NAME variable."
+          exit 1
+        fi
+
+        # Check if signed in by using 'op whoami'
+        if ! op whoami &>/dev/null; then
+          echo "❌ Not signed in to 1Password. Please run 'task setup-account OP_ACCOUNT=your-account' first."
+          exit 1
+        fi
+
+        # Check if jq is installed - it's needed for proper JSON parsing
+        if ! command -v jq &> /dev/null; then
+          echo "⚠️ 'jq' command not found. Using fallback method. For better reliability, install jq."
+          JQ_AVAILABLE=false
+        else
+          JQ_AVAILABLE=true
+        fi
+
+        # Prepare vault filter if provided
+        VAULT_FILTER=""
+        if [ -n "{{.VAULT}}" ]; then
+          VAULT_FILTER="--vault=\"{{.VAULT}}\""
+        fi
+
+        # Determine password field (default to "password" or try with custom field if specified)
+        PASSWORD_FIELD="{{.FIELD}}"
+        if [ -z "$PASSWORD_FIELD" ]; then
+          PASSWORD_FIELD="password"
+        fi
+
+        FORMAT="{{.FORMAT}}"
+        if [ -z "$FORMAT" ]; then
+          FORMAT="json"
+        fi
+
+        # First, let's try to get information about the item to see its structure
+        if [[ "{{.SECRET_NAME}}" =~ ^[a-zA-Z0-9]{26}$ ]]; then
+          # This looks like an ID
+          echo "🔍 Looking up item with ID: {{.SECRET_NAME}}"
+          ITEM_INFO=$(op item get "{{.SECRET_NAME}}" --format=json 2>/dev/null)
+        else
+          # This looks like a name
+          echo "🔍 Looking up item with name: {{.SECRET_NAME}}"
+          if [ -n "{{.VAULT}}" ]; then
+            ITEM_INFO=$(op item get "{{.SECRET_NAME}}" --vault="{{.VAULT}}" --format=json 2>/dev/null)
+          else
+            ITEM_INFO=$(op item get "{{.SECRET_NAME}}" --format=json 2>/dev/null)
+          fi
+        fi
+
+        # If we found the item, extract its details and get the requested field
+        if [ -n "$ITEM_INFO" ]; then
+          # Extract item details based on whether jq is available
+          if [ "$JQ_AVAILABLE" = true ]; then
+            # Use jq for reliable JSON parsing
+            ITEM_ID=$(echo "$ITEM_INFO" | jq -r '.id')
+            ITEM_TITLE=$(echo "$ITEM_INFO" | jq -r '.title')
+            ITEM_VAULT=$(echo "$ITEM_INFO" | jq -r '.vault.id')
+            ITEM_VAULT_NAME=$(echo "$ITEM_INFO" | jq -r '.vault.name')
+
+            # Debug: Print all fields and their purposes
+            echo "📋 Available fields and their purposes:"
+            echo "$ITEM_INFO" | jq -r '.fields[] | "   - \(.id): \(.purpose) (\(.type))"'
+
+            # Extract password directly using 'purpose: PASSWORD'
+            if [ "$PASSWORD_FIELD" = "password" ]; then
+              # Try to find field with PURPOSE=PASSWORD first
+              PASSWORD_ID=$(echo "$ITEM_INFO" | jq -r '.fields[] | select(.purpose=="PASSWORD") | .id')
+              if [ -n "$PASSWORD_ID" ]; then
+                echo "🔑 Found password field with ID: $PASSWORD_ID"
+                PASSWORD_FIELD="$PASSWORD_ID"
+              fi
+            fi
+          else
+            # Fallback to grep pattern matching (less reliable)
+            ITEM_ID=$(echo "$ITEM_INFO" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+            ITEM_TITLE=$(echo "$ITEM_INFO" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
+            ITEM_VAULT=$(echo "$ITEM_INFO" | grep -o '"vault":{[^}]*}' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+            ITEM_VAULT_NAME=$(echo "$ITEM_INFO" | grep -o '"vault":{[^}]*}' | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4)
+          fi
+
+          echo "✅ Found item: $ITEM_TITLE (ID: $ITEM_ID) in vault: $ITEM_VAULT_NAME"
+
+          # Now retrieve the secret using the specific ID or title
+          if [ -z "{{.OUTPUT_FILE}}" ]; then
+            # Try multiple methods to get the password, starting with the most reliable
+
+            # Method 1: Get by item ID and field ID directly
+            if [ "$JQ_AVAILABLE" = true ] && [ -n "$PASSWORD_ID" ]; then
+              echo "📤 Trying to get password by item ID and field ID..."
+              SECRET_VALUE=$(op item get "$ITEM_ID" --fields "$PASSWORD_ID" 2>/dev/null)
+              if [ $? -eq 0 ] && [ -n "$SECRET_VALUE" ]; then
+                echo "✅ Secret retrieved successfully (Method 1)"
+                echo "$SECRET_VALUE"
+                exit 0
+              fi
+            fi
+
+            # Method 2: Get by item ID and field label
+            echo "📤 Trying to get password by item ID and field label..."
+            SECRET_VALUE=$(op item get "$ITEM_ID" --fields "$PASSWORD_FIELD" 2>/dev/null)
+            if [ $? -eq 0 ] && [ -n "$SECRET_VALUE" ]; then
+              echo "✅ Secret retrieved successfully (Method 2)"
+              echo "$SECRET_VALUE"
+              exit 0
+            fi
+
+            # Method 3: Get using the reference path from the JSON
+            if [ "$JQ_AVAILABLE" = true ]; then
+              REF_PATH=$(echo "$ITEM_INFO" | jq -r --arg field "$PASSWORD_FIELD" '.fields[] | select(.id==$field or .label==$field) | .reference')
+              if [ -n "$REF_PATH" ] && [ "$REF_PATH" != "null" ]; then
+                echo "📤 Trying to get password using reference path: $REF_PATH"
+                SECRET_VALUE=$(op read "$REF_PATH" 2>/dev/null)
+                if [ $? -eq 0 ] && [ -n "$SECRET_VALUE" ]; then
+                  echo "✅ Secret retrieved successfully (Method 3)"
+                  echo "$SECRET_VALUE"
+                  exit 0
+                fi
+              fi
+            fi
+
+            # Method 4: Last resort - try to get the entire item and parse manually
+            echo "📤 Trying alternative method to get password..."
+            if [ "$FORMAT" = "text" ]; then
+              op item get "$ITEM_ID" --format="$FORMAT"
+              exit $?
+            else
+              # Try to get all fields as JSON and parse later
+              op item get "$ITEM_ID"
+              exit $?
+            fi
+          else
+            # Save to file
+            OUTPUT_PATH=$(eval echo "{{.OUTPUT_FILE}}")
+            if op item get "$ITEM_ID" --fields "$PASSWORD_FIELD" > "$OUTPUT_PATH" 2>/dev/null; then
+              echo "✅ Secret saved to $OUTPUT_PATH"
+              exit 0
+            else
+              echo "❌ Failed to save secret to file. Trying alternative method..."
+              if op item get "$ITEM_ID" > "$OUTPUT_PATH" 2>/dev/null; then
+                echo "✅ Full item saved to $OUTPUT_PATH (you'll need to extract the password manually)"
+                exit 0
+              fi
+            fi
+          fi
+
+          echo "❌ All methods to extract password failed."
+          echo "💡 Try using the op client directly:"
+          echo "  op item get \"$ITEM_TITLE\" --vault=\"$ITEM_VAULT_NAME\""
+        else
+          echo "❌ Item not found. Please check if '{{.SECRET_NAME}}' exists and you have access."
+
+          # For debugging: list available items to help the user
+          echo ""
+          echo "Available items (first 10):"
+          op item list --limit 10 | head -10
+        fi
+
+        exit 1
+
   create-vault:
     desc: "Create a new vault in 1Password"
     deps:
@@ -65,13 +240,6 @@ tasks:
         op vault create "{{.VAULT_NAME}}"
 
         echo "Vault '{{.VAULT_NAME}}' created successfully."
-
-  list-vaults:
-    desc: "List all vaults in your 1Password account"
-    deps:
-      - ensure-dependencies
-    cmds:
-      - op vault list
 
   store-secret:
     desc: "Store a secret in 1Password"
@@ -114,39 +282,6 @@ tasks:
           password="$SECRET_VALUE"
 
         echo "Secret '{{.SECRET_NAME}}' stored in vault '{{.VAULT_NAME}}'"
-
-  get-secret:
-    desc: "Retrieve a secret from 1Password"
-    deps:
-      - ensure-dependencies
-    vars:
-      SECRET_NAME: "{{.SECRET_NAME | default \"\"}}"
-      VAULT_NAME: "{{.VAULT_NAME | default \"\"}}"
-      OUTPUT_FILE: "{{.OUTPUT_FILE | default \"\"}}"
-    cmds:
-      - |
-        # Check required parameters
-        if [ -z "{{.SECRET_NAME}}" ]; then
-          echo "Please specify the secret name using the SECRET_NAME variable."
-          exit 1
-        fi
-
-        # Prepare vault filter if provided
-        VAULT_FILTER=""
-        if [ -n "{{.VAULT_NAME}}" ]; then
-          VAULT_FILTER="--vault=\"{{.VAULT_NAME}}\""
-        fi
-
-        # Retrieve the secret
-        if [ -z "{{.OUTPUT_FILE}}" ]; then
-          # Display to terminal
-          eval "op item get \"{{.SECRET_NAME}}\" $VAULT_FILTER --fields password"
-        else
-          # Save to file
-          OUTPUT_PATH=$(eval echo "{{.OUTPUT_FILE}}")
-          eval "op item get \"{{.SECRET_NAME}}\" $VAULT_FILTER --fields password" > "$OUTPUT_PATH"
-          echo "Secret '{{.SECRET_NAME}}' saved to $OUTPUT_PATH"
-        fi
 
   encrypt-file:
     desc: "Encrypt a file using 1Password"


### PR DESCRIPTION
**Key Changes:**

* Introduced a modular secrets system supporting both local and 1Password flows.
* Refactored and enhanced secret retrieval via `op` with field/format support.
* Added local encryption tasks using `sops` and `age`.

**Added:**

* `secrets/Taskfile.yaml` routing sub-taskfiles for `local` and `onepassword`.
* `ensure-dependencies`, `create-age-keypair`, `encrypt-file`, `decrypt-file`.
* `get-secret` task with `FIELD`, `FORMAT`, and fallback support.
* `list-secrets` with vault/category filtering and `--reveal` flag.
* Task descriptions and usage examples for improved usability.

**Changed:**

* Refined `get-secret` logic to support item name, ID, field, and format.
* Updated all `op` commands to include `--reveal` for human-friendly output.
* Improved error handling, debug logging, and secret fallback behavior.

**Removed:**

* Legacy `get-secret`, `list-vaults`, `store-secret`, `delete-secret`,
  `encrypt-file`, and `decrypt-file` tasks from `onepassword` scope.
