### PR TITLE
feat: Add reusable Taskfile-based Packer workflows with docs

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,243 @@
+# 📦 Packer Taskfile Tasks
+
+This directory contains reusable [Taskfile](https://taskfile.dev) tasks for
+HashiCorp Packer development workflows, including formatting, validation,
+template management, plugin control, and more.
+
+## 📋 Prerequisites
+
+- [Task](https://taskfile.dev) installed (`brew install go-task/tap/go-task`)
+- [Packer](https://www.packer.io/downloads) installed and in your PATH
+
+## 🎯 Available Tasks
+
+---
+
+### check-packer
+
+Checks for the existence of the `packer` binary in your environment.
+
+```bash
+task check-packer
+```
+
+---
+
+### lint
+
+Formats and validates all Packer files recursively. Runs `packer fmt` and
+`packer validate` for all templates.
+
+```bash
+task lint
+```
+
+---
+
+### format
+
+Auto-formats all packer templates recursively using `packer fmt`.
+
+```bash
+task format
+```
+
+---
+
+### validate
+
+Runs `packer validate` for every Packer template directory in the repo to
+ensure syntax correctness.
+
+```bash
+task validate
+```
+
+---
+
+### packer-fmt
+
+Formats packer template files with additional options.
+
+**Optional Variables:**
+
+- `CHECK` (`true`/`false`): Only check formatting, do not write changes.
+- `RECURSIVE` (`true`/`false`): Recurse into subdirectories.
+- `TEMPLATE_DIR`: Directory containing templates.
+
+```bash
+task packer-fmt
+task packer-fmt CHECK=true
+task packer-fmt RECURSIVE=false TEMPLATE_DIR=subdir/
+```
+
+---
+
+### packer-init
+
+Initializes a Packer working directory (useful for plugin management).
+
+**Optional Variables:**
+
+- `TEMPLATE_DIR`
+- `TEMPLATE`
+
+```bash
+task packer-init TEMPLATE_DIR=foo/
+```
+
+---
+
+### packer-validate
+
+Validates a specific Packer template or directory.
+
+**Optional Variables:**
+
+- `TEMPLATE_DIR`
+- `TEMPLATE`
+- `VAR_FILE`
+
+```bash
+task packer-validate TEMPLATE_DIR=foo/ TEMPLATE=main.pkr.hcl
+```
+
+---
+
+### packer-build
+
+Builds images from a template, supports filtering and forcing.
+
+**Optional Variables:**
+
+- `TEMPLATE_DIR`
+- `TEMPLATE`
+- `VAR_FILE`
+- `ONLY`
+- `EXCEPT`
+- `FORCE` (set to `true` to force a build)
+
+```bash
+task packer-build TEMPLATE_DIR=foo/ ONLY=amazon-ebs FORCE=true
+```
+
+---
+
+### packer-console
+
+Launches an interactive Packer console for variable interpolation and testing.
+
+**Optional Variables:**
+
+- `TEMPLATE_DIR`
+- `TEMPLATE`
+- `VAR_FILE`
+
+```bash
+task packer-console TEMPLATE_DIR=foo/ TEMPLATE=main.pkr.hcl
+```
+
+---
+
+### packer-inspect
+
+Inspects a template and prints details about its configuration.
+
+**Required Variable:**
+
+- `TEMPLATE`
+
+**Optional Variable:**
+
+- `TEMPLATE_DIR`
+
+```bash
+task packer-inspect TEMPLATE_DIR=foo/ TEMPLATE=main.pkr.hcl
+```
+
+---
+
+### packer-hcl2-upgrade
+
+Converts a legacy JSON template to HCL2 and writes it to a target directory.
+
+**Required Variable:**
+
+- `JSON_TEMPLATE`
+
+**Optional Variable:**
+
+- `OUTPUT_DIR` (default: `./hcl-templates`)
+
+```bash
+task packer-hcl2-upgrade JSON_TEMPLATE=old-template.json
+```
+
+---
+
+### packer-plugin-install
+
+Installs a Packer plugin.
+
+**Required Variable:**
+
+- `PLUGIN_NAME`
+
+**Optional Variable:**
+
+- `PLUGIN_VERSION` (default: `latest`)
+
+```bash
+task packer-plugin-install PLUGIN_NAME=github.com/hashicorp/amazon
+```
+
+---
+
+### packer-plugin-list
+
+Lists installed Packer plugins in the environment.
+
+```bash
+task packer-plugin-list
+```
+
+---
+
+## 🛠 Template Variables
+
+- Most commands accept `TEMPLATE_DIR`, `TEMPLATE`, `VAR_FILE` for flexible
+  template management.
+- You can build, validate, or inspect specific templates or apply commands to
+  entire directories.
+
+---
+
+## 📂 Typical Directory Structure
+
+```bash
+.
+├── packer/
+│   ├── main.pkr.hcl
+│   └── variables.pkr.hcl
+├── old-templates/
+│   └── deprecated.json
+├── hcl-templates/
+├── Taskfile.yaml
+└── README.md
+```
+
+---
+
+## 🤝 Contributing
+
+1. Fork the repository.
+1. Create a new branch.
+1. Ensure all tasks run: `task lint` and `task validate`
+1. Format your code: `task format`
+1. Submit your PR!
+
+---
+
+## 📜 License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/packer/Taskfile.yaml
+++ b/packer/Taskfile.yaml
@@ -1,0 +1,272 @@
+---
+version: "3"
+
+tasks:
+  check-packer:
+    desc: "Validate that Packer is installed"
+    cmds:
+      - |
+        if ! command -v packer &> /dev/null; then
+          echo "'packer' command not found. Please install Packer: https://www.packer.io/downloads"
+          exit 1
+        fi
+    silent: true
+
+  lint:
+    desc: "Run packer fmt check on all packer files"
+    deps:
+      - check-packer
+    cmds:
+      - |
+        echo "Running packer fmt check"
+        packer fmt -check -recursive .
+        echo "Running packer validate on all templates"
+        find . -type f -name "*.pkr.hcl" -exec dirname {} \; | uniq | while read dir; do
+          (cd "$dir" && packer validate .)
+        done
+    silent: true
+
+  _packer-base:
+    internal: true
+    deps:
+      - check-packer
+    vars:
+      COMMAND: '{{.COMMAND}}'
+      TEMPLATE_DIR: '{{.TEMPLATE_DIR | default "./"}}'
+      TEMPLATE: '{{.TEMPLATE | default ""}}'
+      BUILDER: '{{.BUILDER | default ""}}'
+      VAR_FILE: '{{.VAR_FILE | default ""}}'
+      ONLY: '{{.ONLY | default ""}}'
+      EXCEPT: '{{.EXCEPT | default ""}}'
+      FORCE: '{{.FORCE | default "false"}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Check for required COMMAND variable
+        if [ -z "{{.COMMAND}}" ]; then
+          echo "ERROR: COMMAND variable is not set"
+          exit 1
+        fi
+
+        # Validate template directory
+        WORKING_DIR=$(pwd)
+        TEMPLATE_DIR="{{ .TEMPLATE_DIR }}"
+        FULL_PATH="$WORKING_DIR/$TEMPLATE_DIR"
+
+        if [ ! -d "$FULL_PATH" ]; then
+          echo "ERROR: Directory does not exist: $FULL_PATH"
+          exit 1
+        fi
+
+        echo "Using path: $FULL_PATH"
+
+        # Configure packer flags
+        FLAGS=""
+
+        if [ -n "{{ .VAR_FILE }}" ]; then
+          FLAGS="$FLAGS -var-file={{ .VAR_FILE }}"
+        fi
+
+        if [ -n "{{ .ONLY }}" ]; then
+          FLAGS="$FLAGS -only={{ .ONLY }}"
+        fi
+
+        if [ -n "{{ .EXCEPT }}" ]; then
+          FLAGS="$FLAGS -except={{ .EXCEPT }}"
+        fi
+
+        if [ "{{ .FORCE }}" = "true" ] && [ "{{ .COMMAND }}" = "build" ]; then
+          FLAGS="$FLAGS -force"
+        fi
+
+        # Execute packer command
+        if [ -n "{{ .TEMPLATE }}" ]; then
+          TEMPLATE_PATH="${FULL_PATH}/{{ .TEMPLATE }}"
+          if [ -f "$TEMPLATE_PATH" ]; then
+            echo "Running packer {{ .COMMAND }} for template: {{ .TEMPLATE }}"
+            cd "$FULL_PATH" && packer {{ .COMMAND }} $FLAGS "{{ .TEMPLATE }}"
+          else
+            echo "ERROR: Template does not exist: $TEMPLATE_PATH"
+            exit 1
+          fi
+        else
+          echo "Running packer {{ .COMMAND }} for all templates in directory"
+          cd "$FULL_PATH" && packer {{ .COMMAND }} $FLAGS .
+        fi
+
+  packer-init:
+    desc: "Initialize a Packer working directory"
+    vars:
+      COMMAND: init
+    cmds:
+      - task: _packer-base
+        vars:
+          COMMAND: '{{.COMMAND}}'
+          TEMPLATE_DIR: '{{.TEMPLATE_DIR}}'
+          TEMPLATE: '{{.TEMPLATE}}'
+
+  packer-validate:
+    desc: "Check that a template is valid"
+    vars:
+      COMMAND: validate
+    cmds:
+      - task: _packer-base
+        vars:
+          COMMAND: '{{.COMMAND}}'
+          TEMPLATE_DIR: '{{.TEMPLATE_DIR}}'
+          TEMPLATE: '{{.TEMPLATE}}'
+          VAR_FILE: '{{.VAR_FILE}}'
+
+  packer-build:
+    desc: "Build image(s) from template"
+    vars:
+      COMMAND: build
+    cmds:
+      - task: _packer-base
+        vars:
+          COMMAND: '{{.COMMAND}}'
+          TEMPLATE_DIR: '{{.TEMPLATE_DIR}}'
+          TEMPLATE: '{{.TEMPLATE}}'
+          VAR_FILE: '{{.VAR_FILE}}'
+          ONLY: '{{.ONLY}}'
+          EXCEPT: '{{.EXCEPT}}'
+          FORCE: '{{.FORCE}}'
+
+  packer-console:
+    desc: "Creates a console for testing variable interpolation"
+    vars:
+      COMMAND: console
+    cmds:
+      - task: _packer-base
+        vars:
+          COMMAND: '{{.COMMAND}}'
+          TEMPLATE_DIR: '{{.TEMPLATE_DIR}}'
+          TEMPLATE: '{{.TEMPLATE}}'
+          VAR_FILE: '{{.VAR_FILE}}'
+
+  packer-fmt:
+    desc: "Format packer template files"
+    deps:
+      - check-packer
+    vars:
+      CHECK: '{{.CHECK | default "false"}}'
+      RECURSIVE: '{{.RECURSIVE | default "true"}}'
+      TEMPLATE_DIR: '{{.TEMPLATE_DIR | default "./"}}'
+    cmds:
+      - |
+        WORKING_DIR=$(pwd)
+        TEMPLATE_DIR="{{ .TEMPLATE_DIR }}"
+        FULL_PATH="$WORKING_DIR/$TEMPLATE_DIR"
+
+        cd "$FULL_PATH"
+
+        FLAGS=""
+        if [ "{{ .CHECK }}" = "true" ]; then
+          FLAGS="$FLAGS -check"
+        fi
+
+        if [ "{{ .RECURSIVE }}" = "true" ]; then
+          FLAGS="$FLAGS -recursive"
+        fi
+
+        packer fmt $FLAGS .
+    silent: true
+
+  packer-inspect:
+    desc: "Inspect a template"
+    deps:
+      - check-packer
+    vars:
+      TEMPLATE_DIR: '{{.TEMPLATE_DIR | default "./"}}'
+      TEMPLATE: '{{.TEMPLATE}}'
+    cmds:
+      - |
+        WORKING_DIR=$(pwd)
+        TEMPLATE_DIR="{{ .TEMPLATE_DIR }}"
+        FULL_PATH="$WORKING_DIR/$TEMPLATE_DIR"
+
+        if [ -n "{{ .TEMPLATE }}" ]; then
+          TEMPLATE_PATH="${FULL_PATH}/{{ .TEMPLATE }}"
+          if [ -f "$TEMPLATE_PATH" ]; then
+            cd "$FULL_PATH" && packer inspect "{{ .TEMPLATE }}"
+          else
+            echo "ERROR: Template does not exist: $TEMPLATE_PATH"
+            exit 1
+          fi
+        else
+          echo "ERROR: TEMPLATE variable is required"
+          exit 1
+        fi
+    silent: true
+
+  validate:
+    desc: "Run packer validate to ensure configuration is syntactically correct"
+    deps:
+      - check-packer
+    cmds:
+      - |
+        find . -type f -name "*.pkr.hcl" -exec dirname {} \; | uniq | while read dir; do
+          echo "Validating templates in $dir"
+          (cd "$dir" && packer validate .)
+        done
+
+  format:
+    desc: "Format packer code"
+    deps:
+      - check-packer
+    cmds:
+      - |
+        packer fmt -recursive .
+
+  packer-hcl2-upgrade:
+    desc: "Upgrade JSON templates to HCL format"
+    deps:
+      - check-packer
+    vars:
+      JSON_TEMPLATE: '{{.JSON_TEMPLATE}}'
+      OUTPUT_DIR: '{{.OUTPUT_DIR | default "./hcl-templates"}}'
+    cmds:
+      - |
+        if [ -z "{{ .JSON_TEMPLATE }}" ]; then
+          echo "ERROR: JSON_TEMPLATE variable is required"
+          exit 1
+        fi
+
+        if [ ! -f "{{ .JSON_TEMPLATE }}" ]; then
+          echo "ERROR: Template does not exist: {{ .JSON_TEMPLATE }}"
+          exit 1
+        fi
+
+        # Create output directory if it doesn't exist
+        mkdir -p "{{ .OUTPUT_DIR }}"
+
+        # Run the upgrade command
+        packer hcl2_upgrade -output-file="{{ .OUTPUT_DIR }}/$(basename "{{ .JSON_TEMPLATE }}" .json).pkr.hcl" "{{ .JSON_TEMPLATE }}"
+    silent: true
+
+  packer-plugin-install:
+    desc: "Install a Packer plugin"
+    deps:
+      - check-packer
+    vars:
+      PLUGIN_NAME: '{{.PLUGIN_NAME}}'
+      PLUGIN_VERSION: '{{.PLUGIN_VERSION | default "latest"}}'
+    cmds:
+      - |
+        if [ -z "{{ .PLUGIN_NAME }}" ]; then
+          echo "ERROR: PLUGIN_NAME variable is required"
+          exit 1
+        fi
+
+        packer plugins install "{{ .PLUGIN_NAME }}" -version "{{ .PLUGIN_VERSION }}"
+    silent: true
+
+  packer-plugin-list:
+    desc: "List installed Packer plugins"
+    deps:
+      - check-packer
+    cmds:
+      - |
+        packer plugins installed
+    silent: true


### PR DESCRIPTION
**Added:**

- Introduced `packer/Taskfile.yaml` with modular tasks for Packer workflows:
  - Formatting, validation, linting, build, init, console, inspect, and plugin management (install/list).
  - Template and variable support for flexible usage scenarios.
- Added comprehensive documentation in `packer/README.md`:
  - Detailed usage for each Taskfile task, parameters, and examples.
  - Workflow descriptions and template directory structure for onboarding.
  - Contribution guidelines and prerequisites.