### PR TITLE
feat: Add advanced core Terraform workflow automation and docs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,17 +7,20 @@ testing, and state management.
 ## 📋 Prerequisites
 
 - [Terraform](https://www.terraform.io/downloads.html) installed
-- [Terragrunt](https://terragrunt.gruntwork.io) installed
+- [Terragrunt](https://terragrunt.gruntwork.io) installed (for Terragrunt tasks)
 - [Go](https://go.dev/dl/) (for running Terratest)
 - [Terratest](https://terratest.gruntwork.io) in your `test` Go module
 - [Task](https://taskfile.dev/#/installation)
   (`brew install go-task/tap/go-task`) installed
+- [tflint](https://github.com/terraform-linters/tflint) (for linting)
 
 ---
 
 ## 🎯 Available Tasks
 
-### check-terraform
+### Core Terraform Tasks
+
+#### check-terraform
 
 Checks if Terraform is installed on your system.
 
@@ -25,23 +28,7 @@ Checks if Terraform is installed on your system.
 task check-terraform
 ```
 
-### check-terragrunt
-
-Checks if Terragrunt is installed on your system.
-
-```bash
-task check-terragrunt
-```
-
-### lint
-
-Runs `terraform fmt -check -recursive` and `tflint` for all `.tf` files, in all directories.
-
-```bash
-task lint
-```
-
-### format
+#### format
 
 Applies `terraform fmt -recursive` to format code in place.
 
@@ -49,7 +36,7 @@ Applies `terraform fmt -recursive` to format code in place.
 task format
 ```
 
-### validate
+#### validate
 
 Runs `terraform validate` in the current directory to check syntax and config correctness.
 
@@ -57,7 +44,185 @@ Runs `terraform validate` in the current directory to check syntax and config co
 task validate
 ```
 
-### terragrunt-init
+#### lint
+
+Runs `terraform fmt -check -recursive` and `tflint` for all `.tf` files, in all directories.
+
+```bash
+task lint
+```
+
+### Standard Terraform Workflow Tasks
+
+#### tf-init-upgrade
+
+Initialize Terraform with upgrade flag.
+
+```bash
+task tf-init-upgrade
+```
+
+#### terraform-plan
+
+Run terraform plan with tfvars file.
+
+```bash
+# Default terraform.tfvars
+task terraform-plan
+
+# Custom tfvars file
+task terraform-plan VAR_FILE=production.tfvars
+
+# With verbose output
+task terraform-plan VERBOSE=true
+```
+
+#### terraform-apply
+
+Run terraform apply with tfvars file.
+
+```bash
+# Interactive apply
+task terraform-apply
+
+# Auto-approve
+task terraform-apply AUTO_APPROVE=true
+
+# Custom tfvars file with auto-approve
+task terraform-apply VAR_FILE=production.tfvars AUTO_APPROVE=true
+```
+
+#### terraform-destroy
+
+Run terraform destroy with tfvars file.
+
+```bash
+# Interactive destroy
+task terraform-destroy
+
+# Auto-approve destroy
+task terraform-destroy AUTO_APPROVE=true
+```
+
+#### terraform-refresh
+
+Refresh Terraform state.
+
+```bash
+task terraform-refresh
+
+# With custom tfvars
+task terraform-refresh VAR_FILE=production.tfvars
+```
+
+### Terraform State Management
+
+#### terraform-state-list
+
+List resources in Terraform state.
+
+```bash
+task terraform-state-list
+```
+
+#### terraform-state-show
+
+Show details of a resource in Terraform state.
+
+```bash
+task terraform-state-show RESOURCE=aws_instance.example
+```
+
+#### terraform-import
+
+Import existing infrastructure into Terraform state.
+
+```bash
+task terraform-import RESOURCE=aws_instance.example ID=i-1234567890abcdef0
+
+# With custom tfvars
+task terraform-import RESOURCE=aws_instance.example ID=i-1234567890abcdef0 VAR_FILE=production.tfvars
+```
+
+### Terraform Output
+
+#### terraform-output
+
+Show Terraform outputs.
+
+```bash
+# Show all outputs
+task terraform-output
+
+# Show specific output
+task terraform-output OUTPUT=instance_ip
+
+# Output as JSON
+task terraform-output FORMAT=json
+```
+
+### Composite Workflow Tasks (Recommended)
+
+#### tf-check
+
+Format and validate Terraform configuration.
+
+```bash
+task tf-check
+```
+
+#### tf-plan
+
+Full Terraform plan workflow (init, format, validate, plan).
+
+```bash
+task tf-plan
+
+# With custom tfvars
+task tf-plan VAR_FILE=production.tfvars
+
+# With verbose output
+task tf-plan VERBOSE=true
+```
+
+#### tf-apply
+
+Full Terraform apply workflow (init, format, validate, apply).
+
+```bash
+# Interactive apply
+task tf-apply
+
+# Auto-approve
+task tf-apply AUTO_APPROVE=true
+
+# Custom tfvars with auto-approve
+task tf-apply VAR_FILE=production.tfvars AUTO_APPROVE=true
+```
+
+#### tf-destroy
+
+Full Terraform destroy workflow (init, plan destroy, destroy).
+
+```bash
+# Interactive destroy
+task tf-destroy
+
+# Auto-approve
+task tf-destroy AUTO_APPROVE=true
+```
+
+### Terragrunt Tasks
+
+#### check-terragrunt
+
+Checks if Terragrunt is installed on your system.
+
+```bash
+task check-terragrunt
+```
+
+#### terragrunt-init
 
 Initializes one or all Terragrunt modules.
 Required: `DEPLOYMENT`, `ENV`, `REGION`
@@ -75,9 +240,10 @@ task terragrunt-init DEPLOYMENT=myenv ENV=dev REGION=us-east-2
 task terragrunt-init DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
 ```
 
-### terragrunt-plan
+#### terragrunt-plan
 
 Runs `terragrunt plan` (`run-all plan`) for all or a specific module.
+
 **All modules**:
 
 ```bash
@@ -90,7 +256,7 @@ task terragrunt-plan DEPLOYMENT=myenv ENV=dev REGION=us-east-2
 task terragrunt-plan DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
 ```
 
-### terragrunt-apply
+#### terragrunt-apply
 
 Runs `terragrunt apply` (`run-all apply`) for all or a specific module.
 All apply and destroy operations are non-interactive (`-auto-approve`).
@@ -107,7 +273,7 @@ task terragrunt-apply DEPLOYMENT=myenv ENV=dev REGION=us-east-2
 task terragrunt-apply DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
 ```
 
-### terragrunt-destroy
+#### terragrunt-destroy
 
 Runs `terragrunt destroy` (`run-all destroy`) for all or a specific module.
 
@@ -123,7 +289,7 @@ task terragrunt-destroy DEPLOYMENT=myenv ENV=dev REGION=us-east-2
 task terragrunt-destroy DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
 ```
 
-### terragrunt-state-remove-all
+#### terragrunt-state-remove-all
 
 Removes all resources from the Terraform state for a specified module or all
 modules.
@@ -142,11 +308,13 @@ task terragrunt-state-remove-all DEPLOYMENT=myenv ENV=dev REGION=us-east-2
 task terragrunt-state-remove-all DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
 ```
 
-### run-terratest
+### Testing
+
+#### run-terratest
 
 Runs Terratest integration tests in the `test/` directory.
 
-#### Supported options (all optional)
+##### Supported options (all optional)
 
 - `TIMEOUT`: Max duration (default: `60m`)
 - `DESTROY`: Destroy infra after test (default: `true`)
@@ -170,12 +338,43 @@ task run-terratest TIMEOUT=30m DESTROY=false VERBOSE=true LOG_TO_FILE=true LOG_P
 
 ## 📝 Example Usage
 
-**Format and validate code:**
+### Standard Terraform Workflow
+
+**Quick apply with safety checks:**
 
 ```bash
-task format
-task validate
+# See what will change
+task tf-plan
+
+# Apply changes
+task tf-apply AUTO_APPROVE=true
 ```
+
+**Working with different environments:**
+
+```bash
+# Development
+task tf-apply VAR_FILE=dev.tfvars AUTO_APPROVE=true
+
+# Production (interactive for safety)
+task tf-plan VAR_FILE=production.tfvars
+task tf-apply VAR_FILE=production.tfvars
+```
+
+**State management:**
+
+```bash
+# List all resources
+task terraform-state-list
+
+# Import existing infrastructure
+task terraform-import RESOURCE=unifi_firewall_rule.example ID=12345
+
+# Show resource details
+task terraform-state-show RESOURCE=unifi_firewall_rule.example
+```
+
+### Terragrunt Workflow
 
 **Plan and apply infrastructure:**
 
@@ -188,18 +387,6 @@ task terragrunt-apply DEPLOYMENT=myenv ENV=dev REGION=us-east-2
 
 ```bash
 task terragrunt-apply DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
-```
-
-**Remove state for a module:**
-
-```bash
-task terragrunt-state-remove-all DEPLOYMENT=myenv ENV=dev REGION=us-east-2 MODULE=mymodule
-```
-
-**Terratest, verbose with logs:**
-
-```bash
-task run-terratest VERBOSE=true LOG_TO_FILE=true LOG_PATH=/tmp/test.log
 ```
 
 ---
@@ -216,23 +403,25 @@ includes:
 tasks:
   my-custom-task:
     cmds:
-      - task: tf:terragrunt-plan
+      - task: tf:terraform-plan
         vars:
-          DEPLOYMENT: myenv
-          ENV: dev
-          REGION: us-west-1
+          VAR_FILE: custom.tfvars
 ```
 
 ---
 
 ## 🔍 Notes
 
-- `DEPLOYMENT`, `ENV`, and `REGION` are required for all Terragrunt tasks.
-- `MODULE` is optional, to target a specific submodule directory.
+- Standard Terraform tasks use `terraform.tfvars` by default, but support
+  custom tfvars files via `VAR_FILE`
+- `AUTO_APPROVE` flag is available for apply and destroy operations
+- `VERBOSE` flag enables detailed Terraform debug logging
+- Terragrunt tasks require `DEPLOYMENT`, `ENV`, and `REGION` variables
+- `MODULE` is optional for Terragrunt tasks, to target a specific submodule directory
 - Terragrunt commands default to non-interactive, auto-approved, and disable
-  state file locking.
-- Terratest assumes your tests are in a `test` subdirectory.
-- `tflint` must be installed to use the `lint` task.
+  state file locking
+- Terratest assumes your tests are in a `test` subdirectory
+- `tflint` must be installed to use the `lint` task
 
 ## 🤝 Contributing
 

--- a/terraform/Taskfile.yaml
+++ b/terraform/Taskfile.yaml
@@ -355,3 +355,238 @@ tasks:
           terraform init $FLAGS
         fi
     silent: true
+
+  terraform-plan:
+    desc: Run terraform plan with tfvars file
+    deps:
+      - check-terraform
+    vars:
+      VAR_FILE: '{{.VAR_FILE | default "terraform.tfvars"}}'
+      VERBOSE: '{{.VERBOSE | default "false"}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Enable verbose logging if requested
+        if [ "{{.VERBOSE}}" = "true" ]; then
+          export TF_LOG=DEBUG
+        fi
+
+        # Check if var file exists
+        if [ -f "{{.VAR_FILE}}" ]; then
+          echo "Running terraform plan with {{.VAR_FILE}}"
+          terraform plan -var-file={{.VAR_FILE}}
+        else
+          echo "Running terraform plan (no var file found)"
+          terraform plan
+        fi
+    silent: false
+
+  terraform-apply:
+    desc: Run terraform apply with tfvars file
+    deps:
+      - check-terraform
+    vars:
+      VAR_FILE: '{{.VAR_FILE | default "terraform.tfvars"}}'
+      AUTO_APPROVE: '{{.AUTO_APPROVE | default "false"}}'
+      VERBOSE: '{{.VERBOSE | default "false"}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Enable verbose logging if requested
+        if [ "{{.VERBOSE}}" = "true" ]; then
+          export TF_LOG=DEBUG
+        fi
+
+        # Build command flags
+        FLAGS=""
+        if [ "{{.AUTO_APPROVE}}" = "true" ]; then
+          FLAGS="-auto-approve"
+        fi
+
+        # Check if var file exists
+        if [ -f "{{.VAR_FILE}}" ]; then
+          echo "Running terraform apply with {{.VAR_FILE}}"
+          terraform apply -var-file={{.VAR_FILE}} $FLAGS
+        else
+          echo "Running terraform apply (no var file found)"
+          terraform apply $FLAGS
+        fi
+    silent: false
+
+  terraform-destroy:
+    desc: Run terraform destroy with tfvars file
+    deps:
+      - check-terraform
+    vars:
+      VAR_FILE: '{{.VAR_FILE | default "terraform.tfvars"}}'
+      AUTO_APPROVE: '{{.AUTO_APPROVE | default "false"}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Build command flags
+        FLAGS=""
+        if [ "{{.AUTO_APPROVE}}" = "true" ]; then
+          FLAGS="-auto-approve"
+        fi
+
+        # Check if var file exists
+        if [ -f "{{.VAR_FILE}}" ]; then
+          echo "Running terraform destroy with {{.VAR_FILE}}"
+          terraform destroy -var-file={{.VAR_FILE}} $FLAGS
+        else
+          echo "Running terraform destroy (no var file found)"
+          terraform destroy $FLAGS
+        fi
+    silent: false
+
+  terraform-refresh:
+    desc: Refresh Terraform state
+    deps:
+      - check-terraform
+    vars:
+      VAR_FILE: '{{.VAR_FILE | default "terraform.tfvars"}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Check if var file exists
+        if [ -f "{{.VAR_FILE}}" ]; then
+          echo "Running terraform refresh with {{.VAR_FILE}}"
+          terraform refresh -var-file={{.VAR_FILE}}
+        else
+          echo "Running terraform refresh (no var file found)"
+          terraform refresh
+        fi
+    silent: false
+
+  terraform-output:
+    desc: Show Terraform outputs
+    deps:
+      - check-terraform
+    vars:
+      OUTPUT: '{{.OUTPUT | default ""}}'
+      FORMAT: '{{.FORMAT | default ""}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        FLAGS=""
+        if [ -n "{{.FORMAT}}" ]; then
+          FLAGS="-{{.FORMAT}}"
+        fi
+
+        if [ -n "{{.OUTPUT}}" ]; then
+          terraform output $FLAGS {{.OUTPUT}}
+        else
+          terraform output $FLAGS
+        fi
+    silent: false
+
+  terraform-import:
+    desc: Import existing infrastructure into Terraform state
+    deps:
+      - check-terraform
+    vars:
+      RESOURCE: '{{.RESOURCE}}'
+      ID: '{{.ID}}'
+      VAR_FILE: '{{.VAR_FILE | default "terraform.tfvars"}}'
+    cmds:
+      - |
+        set -euo pipefail
+
+        if [ -z "{{.RESOURCE}}" ] || [ -z "{{.ID}}" ]; then
+          echo "ERROR: RESOURCE and ID variables are required"
+          echo "Usage: task terraform-import RESOURCE=aws_instance.example ID=i-1234567890abcdef0"
+          exit 1
+        fi
+
+        # Check if var file exists
+        if [ -f "{{.VAR_FILE}}" ]; then
+          echo "Importing {{.RESOURCE}} with ID {{.ID}} using {{.VAR_FILE}}"
+          terraform import -var-file={{.VAR_FILE}} {{.RESOURCE}} {{.ID}}
+        else
+          echo "Importing {{.RESOURCE}} with ID {{.ID}}"
+          terraform import {{.RESOURCE}} {{.ID}}
+        fi
+    silent: false
+
+  terraform-state-list:
+    desc: List resources in Terraform state
+    deps:
+      - check-terraform
+    cmds:
+      - terraform state list
+    silent: false
+
+  terraform-state-show:
+    desc: Show details of a resource in Terraform state
+    deps:
+      - check-terraform
+    vars:
+      RESOURCE: '{{.RESOURCE}}'
+    cmds:
+      - |
+        if [ -z "{{.RESOURCE}}" ]; then
+          echo "ERROR: RESOURCE variable is required"
+          echo "Usage: task terraform-state-show RESOURCE=aws_instance.example"
+          exit 1
+        fi
+        terraform state show {{.RESOURCE}}
+    silent: false
+
+  # Composite tasks for common workflows
+
+  tf-init-upgrade:
+    desc: Initialize Terraform with upgrade flag
+    deps:
+      - check-terraform
+    cmds:
+      - terraform init -upgrade
+    silent: false
+
+  tf-check:
+    desc: Format and validate Terraform configuration
+    cmds:
+      - task: format
+      - task: validate
+      - task: lint
+    silent: false
+
+  tf-plan:
+    desc: Full Terraform plan workflow (init, format, validate, plan)
+    cmds:
+      - task: tf-init-upgrade
+      - task: tf-check
+      - task: terraform-plan
+        vars:
+          VAR_FILE: '{{.VAR_FILE}}'
+          VERBOSE: '{{.VERBOSE}}'
+    silent: false
+
+  tf-apply:
+    desc: Full Terraform apply workflow (init, format, validate, apply)
+    cmds:
+      - task: tf-init-upgrade
+      - task: tf-check
+      - task: terraform-apply
+        vars:
+          VAR_FILE: '{{.VAR_FILE}}'
+          AUTO_APPROVE: '{{.AUTO_APPROVE}}'
+          VERBOSE: '{{.VERBOSE}}'
+    silent: false
+
+  tf-destroy:
+    desc: Full Terraform destroy workflow (init, plan destroy, destroy)
+    cmds:
+      - task: tf-init-upgrade
+      - |
+        echo "Planning destroy operation..."
+      - terraform plan -destroy -var-file={{.VAR_FILE | default "terraform.tfvars"}}
+      - task: terraform-destroy
+        vars:
+          VAR_FILE: '{{.VAR_FILE}}'
+          AUTO_APPROVE: '{{.AUTO_APPROVE}}'
+    silent: false


### PR DESCRIPTION
**Added:**

- Introduced new Taskfile tasks for core Terraform workflows:
  - `terraform-plan` to support plans with custom tfvars/verbosity
  - `terraform-apply` with support for `AUTO_APPROVE`, custom tfvars, verbose
  - `terraform-destroy`, `terraform-refresh`, `terraform-import`, state tasks
  - `terraform-output` for selective and formatted outputs
  - Composite workflows: `tf-init-upgrade`, `tf-check`, `tf-plan`, `tf-apply`, and `tf-destroy` for streamlined init, validate, plan/destroy, and apply
- Extended documentation in `README.md` covering all new commands with detailed usage, examples, and options

**Changed:**

- Reorganized README task documentation for clarity
  - Grouped tasks by standard Terraform, state management, Terragrunt, tests
  - Provided improved and environment-aware usage samples
  - Clarified variable inheritance and recommend workflow best practices