### PR TITLE
feat: Improve handling of UBIQUITI\_CONTROLLER\_HOST in Taskfile

### DIFF
--- a/unifi/Taskfile.yaml
+++ b/unifi/Taskfile.yaml
@@ -5,8 +5,7 @@ version: "3"
 vars:
   # The UBIQUITI_CONTROLLER_HOST should be provided via environment variable
   # or explicitly set when running the task
-  UBIQUITI_CONTROLLER_HOST:
-    sh: if [ -z "${UBIQUITI_CONTROLLER_HOST}" ]; then echo "Please set UBIQUITI_CONTROLLER_HOST"; exit 1; else echo "${UBIQUITI_CONTROLLER_HOST}"; fi
+  UBIQUITI_CONTROLLER_HOST: '{{.UBIQUITI_CONTROLLER_HOST | default "localhost"}}'
   UBIQUITI_BASE_URL: "https://{{.UBIQUITI_CONTROLLER_HOST}}"
 
 tasks:


### PR DESCRIPTION
**Changed:**

* Updated `UBIQUITI_CONTROLLER_HOST` var to use Taskfile's `default` function for cleaner and safer fallback to `"localhost"` if not explicitly set.
* Removed shell-based check to simplify variable resolution logic.