### PR TITLE
chore: update renovate config to improve automerge reliability

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,8 @@
   suppressNotifications: [
     'prIgnoreNotification',
   ],
-  rebaseWhen: 'conflicted',
+  // 'auto' keeps automerge PRs rebased/up-to-date; 'conflicted' left green PRs stranded.
+  rebaseWhen: 'auto',
   commitBodyTable: true,
   labels: [
     'renovate',
@@ -42,6 +43,31 @@
       ],
       automerge: true,
       automergeType: 'branch',
+    },
+    {
+      description: 'Auto merge GitHub Actions major updates',
+      matchManagers: [
+        'github-actions',
+      ],
+      matchDatasources: [
+        'github-tags',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      automerge: true,
+      automergeType: 'pr',
+    },
+    {
+      description: 'Auto merge pre-commit hook major updates',
+      matchManagers: [
+        'pre-commit',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      automerge: true,
+      automergeType: 'pr',
     },
     {
       description: 'Auto merge non-major updates for other dependencies',


### PR DESCRIPTION
**Key Changes:**

- Switched `rebaseWhen` from `conflicted` to `auto` to keep automerge PRs continuously rebased and prevent them from stalling
- Extended automerge coverage to include major version updates for GitHub Actions and pre-commit hooks
- Major updates for these tool categories will now merge via PR (not branch) to retain visibility

**Added:**

- GitHub Actions major update rule - New package rule targets `github-actions` manager with `github-tags` datasource for major updates, enabling automerge via PR
- Pre-commit major update rule - New package rule targets `pre-commit` manager for major updates, enabling automerge via PR

**Changed:**

- Rebase strategy - Updated `rebaseWhen` to `'auto'` so automerge PRs stay up-to-date rather than being left stranded when green but behind base branch